### PR TITLE
Fix run_td script permission denied issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ sudo ./setup-tdx-guest.sh
 
 1. Now that you have a TD guest image, let’s boot it with the provided script.
 
+NOTE: It is recommended to run the script with normal user. In this case, please make sure that the user belongs to kvm group. To add the current user to kvm group:
+
+```bash
+sudo usemod -aG kvm $USER
+```
+Close the current shell and open a new one to apply this group settings.
+
 ```bash
 cd tdx/guest-tools
 TD_IMG=<path_to_td_qcow2_image> ./run_td.sh

--- a/guest-tools/run_td.sh
+++ b/guest-tools/run_td.sh
@@ -18,6 +18,11 @@ fi
 TD_IMG=${TD_IMG:-${PWD}/ubuntu-23.10-td.qcow2}
 TDVF_FIRMWARE=/usr/share/ovmf/OVMF.fd
 
+if ! groups | grep -qw "kvm"; then
+    echo "Please add user $USER to kvm group to run this script (usermod -aG kvm $USER && log out)."
+    exit 1
+fi
+
 set -e
 
 ###################### RUN VM WITH TDX SUPPORT ##################################


### PR DESCRIPTION
To be able to run the run_td script with normal user the user must be assigned to group kvm. Update README and add a check in the run_td script