### PR TITLE
Work around for login prompt missing issue

### DIFF
--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -31,3 +31,12 @@ if [ $? -ne 0 ]; then
   grub-install
 fi
 
+# FIXME : with the current kernel, we do not have login prompt with getty
+# as a work around, use nomodeset to tell kernel to use BIOS mode
+grep -E "GRUB_CMDLINE_LINUX.*=.*\".*nomodeset.*\"" /etc/default/grub &> /dev/null
+if [ $? -ne 0 ]; then
+  sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 nomodeset\"/g" /etc/default/grub
+  update-grub
+  grub-install
+fi
+


### PR DESCRIPTION
The released intel-opt kernel has an issue with video mode setting that made display unavailable for login prompt on the TTY, as a work around, disable the video mode setting in the kernel   