### PR TITLE
Add vsock device for TD Quote Generation

### DIFF
--- a/guest-tools/td_guest.xml.template
+++ b/guest-tools/td_guest.xml.template
@@ -43,6 +43,10 @@
       <source mode='bind'/>
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>
+  <vsock model='virtio'>
+    <cid auto='yes' address='3'/>
+    <address type='pci' domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>
+  </vsock>
   </devices>
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>


### PR DESCRIPTION
Add vsock device to libvirt guest xml template to allow TD quote generation when a TD is launched with libvirt.