### PR TITLE
Default TD launch policy to non-debug.

### DIFF
--- a/guest-tools/td_guest.xml.template
+++ b/guest-tools/td_guest.xml.template
@@ -50,7 +50,7 @@
   </devices>
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
-    <policy>0x10000001</policy>
+    <policy>0x10000000</policy>
   </launchSecurity>
   <qemu:commandline>
     <qemu:arg value='-cpu'/>


### PR DESCRIPTION
This change is to launch a TD in TDX non-Debug mode by default.  If a user wants to debug, they should have to explicitly set bit 0 to opt in, in my opinion.

Reference for this in the Intel TDX Module 1.0 Specification, table 22.2 and section 16.3 (https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/documentation.html),

and the TDX source (https://github.com/intel/qemu-tdx/blob/7a97b8940d938d0d5740c0513c9acf0053c6cb85/target/i386/kvm/tdx.c#L51)