### PR TITLE
Remove useless apt cmd and IMA config in TDX image creation

### DIFF
--- a/guest-tools/image/cloud-init-data/user-data
+++ b/guest-tools/image/cloud-init-data/user-data
@@ -29,11 +29,6 @@ packages:
   - golang-doc
   - ntp
 
-runcmd:
-  - apt install --fix-broken
-  - sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="[^"]*/& ima_hash=sha384 ima_policy=critical_data/' /etc/default/grub.d/50-cloudimg-settings.cfg
-  - update-grub2
-
 # HACK way to set root password
 # https://github.com/vmware/photon/issues/931
 # set root password to 123456

--- a/guest-tools/image/cloud-init-data/user-data.template
+++ b/guest-tools/image/cloud-init-data/user-data.template
@@ -29,11 +29,6 @@ packages:
   - golang-doc
   - ntp
 
-runcmd:
-  - apt install --fix-broken
-  - sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="[^"]*/& ima_hash=sha384 ima_policy=critical_data/' /etc/default/grub.d/50-cloudimg-settings.cfg
-  - update-grub2
-
 # HACK way to set root password
 # https://github.com/vmware/photon/issues/931
 # set root password to 123456


### PR DESCRIPTION
The TDX setup process is nice and won't break the apt system, so "apt install --fix-broken" is redundant.
Also remove IMA parameters from guest kernel cmdline to avoid confusion. Enabling TDX doesn't require kernel IMA at all.