### PR TITLE
Improve attestation setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,15 @@ cd tdx/attestation
 sudo ./setup-attestation-host.sh
 ```
 
+`Reboot` the system and verify that sgx devices have proper user and group.
+
+```bash
+$ ls -l /dev/sgx_*
+crw-rw-rw- 1 root sgx     10, 125 Apr  3 21:14 /dev/sgx_enclave
+crw-rw---- 1 root sgx_prv 10, 126 Apr  3 21:14 /dev/sgx_provision
+crw-rw---- 1 root sgx     10, 124 Apr  3 21:14 /dev/sgx_vepc
+```
+
 2. Verify the QGS service is running properly.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -345,8 +345,6 @@ Re-enter user password: <PCCS-SERVER-USER-PASSWORD>
 Do you want to generate insecure HTTPS key and cert for PCCS service? [Y] (Y/N) :N
 ```
 
-NOTE: You may answer "Y" to the last question if you would like to generate a self-signed cert for testing purposes. Otherwise, you should install a certificate that is signed by a recognized certificate authority.
-
 6. Restart the PCCS service.
 
 ```bash
@@ -381,34 +379,6 @@ retrieval_result.csv has been generated successfully, however the data couldn't 
 ```
 
 If the failure occurred, you must boot into the BIOS and perform `SGX Factory Reset` (go to `Socket Configuration > Processor Configuration`) and execute the registration process again.
-
-9. (Optional) Edit SGX configuration file
-
-If you configured PCCS with a self-signed certificate, edit `/etc/sgx_default_qcnl.conf` on the host and change the following line:
-
-```
-,"use_secure_cert": true
-```
-
-to:
-
-```
-,"use_secure_cert": false
-```
-
-Now restart the `qgsd` and `pccs` services:
-
-```
-sudo systemctl restart qgsd
-sudo systemctl restart pccs
-```
-
-and verify they are running properly:
-
-```
-sudo systemctl status qgsd
-sudo systemctl status pccs
-```
 
 ### Setup [Intel Trust Authority (ITA) Client](https://github.com/intel/trustauthority-client-for-go) on Guest 
 1. [Boot a TD guest](#boot-td-guest) and connect to it.

--- a/attestation/setup-attestation-host.sh
+++ b/attestation/setup-attestation-host.sh
@@ -30,8 +30,6 @@ apt install --yes libsgx-ae-id-enclave \
 
 # libsgx-enclave-common/etc/udev/rules.d/94-sgx-enclave.rules
 
-chown root:sgx /dev/sgx_provision
-chmod g+rw /dev/sgx_provision
-
 usermod -aG sgx_prv qgsd
+
 


### PR DESCRIPTION
- Add reboot instruction in README  
    after the setup script run for attestation, we need to reboot
    to have the right owner & group for /dev/sgx_provision (from udev rule)

- Remove README section on use_secure_cert  
    with the version 1.18-0ubuntu2 of libsgx-dcap-default-qpl
    the use_secure_cert is set to false by default

- setup-attestation-host.sh : do not set user and group for /dev/sgx_provision  
    the udev rules will take care of it
