### PR TITLE
Fix network module missing

### DIFF
--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -35,8 +35,10 @@ EOF
 
 apt update
 
+# modules-extra is needed (igc for example)
 apt install --yes --allow-downgrades \
     linux-intel-opt \
+    linux-modules-extra-intel-opt \
     qemu-system-x86 \
     libvirt-daemon-system \
     libvirt-clients \


### PR DESCRIPTION
In https://github.com/canonical/tdx/pull/47 , we introduced a regression by not installing modules-extra anymore. This module is still needed for some kernel modules that live in modules-extra (igc, ...)

Fixes #54 