### PR TITLE
Add intel kernel as option that can be selected at guest image creation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ cd tdx/guest-tools/image/
 sudo ./create-td-image.sh
 ```
 
+The TD guest image uses the Ubuntu generic kernel by default, intel kernel can be selected by using
+the environment variable `TDX_GUEST_SETUP_INTEL_KERNEL`.
+
+```bash
+sudo TDX_GUEST_SETUP_INTEL_KERNEL=1 ./create-td-image.sh
+```
+
 The produced TD guest image is `tdx-guest-ubuntu-24.04.qcow2`.
 
 The root password is set to `123456`.

--- a/guest-tools/image/create-td-image.sh
+++ b/guest-tools/image/create-td-image.sh
@@ -213,7 +213,12 @@ setup_guest_image() {
     virt-customize -a /tmp/${GUEST_IMG} \
         --copy-in ${CURR_DIR}/../../setup-tdx-guest.sh:/tmp/
     virt-customize -a /tmp/${GUEST_IMG} \
-        --copy-in ${CURR_DIR}/../../attestation/:/tmp/
+       --copy-in ${CURR_DIR}/../../attestation/:/tmp/
+    # export environment variables to guest
+    # all environment variables with prefix : TDX_GUEST_SETUP_
+    declare -px | grep TDX_GUEST_SETUP_ > ${CURR_DIR}/tdx-guest-setup-env
+    virt-customize -a /tmp/${GUEST_IMG} \
+       --copy-in ${CURR_DIR}/tdx-guest-setup-env:/tmp/
     virt-customize -a /tmp/${GUEST_IMG} \
         --run-command "/tmp/setup.sh"
     if [ $? -eq 0 ]; then

--- a/guest-tools/image/setup.sh
+++ b/guest-tools/image/setup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# caller can set a list of environment variables by putting them into the file /tmp/tdx-guest-setup-env
+if [ -f /tmp/tdx-guest-setup-env ]; then
+  source /tmp/tdx-guest-setup-env
+fi
+
 apt update
 
 # Utilities packages for automated testing

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -2,8 +2,10 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# for now, use the generic kernel
-KERNEL_RELEASE=6.8.0-22-generic
+# use can use -intel kernel by setting TDX_GUEST_SETUP_INTEL_KERNEL
+if [ ! -z "${TDX_GUEST_SETUP_INTEL_KERNEL}" ]; then
+   KERNEL_RELEASE=6.8.0-1001-intel
+fi
 
 # grub: switch to kernel version
 grub_switch_kernel() {
@@ -33,20 +35,25 @@ Pin: release o=LP-PPA-kobuk-team-tdx
 Pin-Priority: 4000
 EOF
 
-apt update
+# upgrade the system to have the latest components (mostly generic kernel)
+apt upgrade --yes
 
 # install TDX feature
 # install modules-extra to have tdx_guest module
 apt install --yes --allow-downgrades \
-   linux-image-unsigned-${KERNEL_RELEASE} \
-   linux-modules-extra-${KERNEL_RELEASE} \
    shim-signed \
    grub-efi-amd64-signed \
    grub-efi-amd64-bin \
    tdx-tools-guest \
    python3-pytdxmeasure
 
-grub_switch_kernel ${KERNEL_RELEASE}
+# if a specific kernel has to be used
+# TODO : install linux-modules-extra
+if [ ! -z "${KERNEL_RELEASE}" ]; then
+  apt install --yes --allow-downgrades \
+    linux-image-unsigned-${KERNEL_RELEASE}
+  grub_switch_kernel ${KERNEL_RELEASE}
+fi
 
 # setup attestation
 ${SCRIPT_DIR}/attestation/setup-guest.sh


### PR DESCRIPTION
Use has to set the environment variable TDX_GUEST_SETUP_INTEL_KERNEL at setup-tdx-guest.sh script invocation