### PR TITLE
Fix tdx components pinning despite unattended upgrade

### DIFF
--- a/guest-tools/image/create-td-image.sh
+++ b/guest-tools/image/create-td-image.sh
@@ -217,6 +217,7 @@ setup_guest_image() {
     virt-customize -a /tmp/${GUEST_IMG} \
        --copy-in ${CURR_DIR}/setup.sh:/tmp/ \
        --copy-in ${CURR_DIR}/../../setup-tdx-guest.sh:/tmp/ \
+       --copy-in ${CURR_DIR}/../../setup-tdx-common:/tmp/ \
        --copy-in ${CURR_DIR}/../../attestation/:/tmp/ \
        --copy-in ${CURR_DIR}/tdx-guest-setup-env:/tmp/ \
        --run-command "/tmp/setup.sh"

--- a/setup-tdx-common
+++ b/setup-tdx-common
@@ -20,11 +20,11 @@ Package: *
 Pin: release o=${distro_id}
 Pin-Priority: 4000
 EOF
+
   cat <<EOF | tee /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
-Unattended-Upgrade::Allowed-Origins·{
-··"${distro_id}:${distro_codename}";
+Unattended-Upgrade::Allowed-Origins {
+  "${distro_id}:${distro_codename}";
 };
-Unattended-Upgrade::Allow-downgrade·"true";
-}
+Unattended-Upgrade::Allow-downgrade "true";
 EOF
 }

--- a/setup-tdx-common
+++ b/setup-tdx-common
@@ -1,0 +1,30 @@
+# Pinning the packages of specific PPA
+#
+# unattended-upgrade:
+# unattended-upgrade will temporarily set APT pinning for the archives
+# it will ignore the pinning configuration for PPAs that are not listed
+# in the Allowed-Origins list
+# we have to add the PPA into this list to prevent unattended from
+# setting its pinning priority to -32768
+# we also need to tell unattended-upgrade to allow the downgrade
+# in case the packages in the PPA have older versions than the ones
+# from Ubuntu archive
+add_kobuk_ppa() {
+  distro_id=LP-PPA-kobuk-team-tdx
+  distro_codename=noble
+
+  add-apt-repository -y ppa:kobuk-team/tdx
+
+  cat <<EOF | tee /etc/apt/preferences.d/kobuk-team-tdx-pin-4000
+Package: *
+Pin: release o=${distro_id}
+Pin-Priority: 4000
+EOF
+  cat <<EOF | tee /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
+Unattended-Upgrade::Allowed-Origins·{
+··"${distro_id}:${distro_codename}";
+};
+Unattended-Upgrade::Allow-downgrade·"true";
+}
+EOF
+}

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -45,7 +45,6 @@ apt install --yes software-properties-common &> /dev/null
 rm -f /etc/apt/preferences.d/kobuk-team-tdx-*
 rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 
-# add kobuk PPA
 add_kobuk_ppa
 
 # upgrade the system to have the latest components (mostly generic kernel)

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -7,6 +7,8 @@ if [ ! -z "${TDX_GUEST_SETUP_INTEL_KERNEL}" ]; then
    KERNEL_RELEASE=6.8.0-1001-intel
 fi
 
+source ${SCRIPT_DIR}/setup-tdx-common
+
 # grub: switch to kernel version
 grub_switch_kernel() {
     KERNELVER=$1
@@ -41,15 +43,10 @@ apt install --yes software-properties-common &> /dev/null
 
 # cleanup
 rm -f /etc/apt/preferences.d/kobuk-team-tdx-*
+rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 
-add-apt-repository -y ppa:kobuk-team/tdx
-
-# PPA pinning
-cat <<EOF | tee /etc/apt/preferences.d/kobuk-team-tdx-pin-4000
-Package: *
-Pin: release o=LP-PPA-kobuk-team-tdx
-Pin-Priority: 4000
-EOF
+# add kobuk PPA
+add_kobuk_ppa
 
 # upgrade the system to have the latest components (mostly generic kernel)
 apt upgrade --yes

--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 on_exit() {
@@ -19,6 +18,8 @@ _error() {
 }
 
 trap "on_exit" EXIT
+
+source ${SCRIPT_DIR}/setup-tdx-common
 
 KERNEL_RELEASE=6.8.0-1001-intel
 
@@ -67,18 +68,13 @@ apt install --yes software-properties-common gawk &> /dev/null
 
 # cleanup
 rm -f /etc/apt/preferences.d/kobuk-team-tdx-*
+rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 
 # stop at error
 set -e
 
-add-apt-repository -y ppa:kobuk-team/tdx
-
-# PPA pinning
-cat <<EOF | tee /etc/apt/preferences.d/kobuk-team-tdx-pin-4000
-Package: *
-Pin: release o=LP-PPA-kobuk-team-tdx
-Pin-Priority: 4000
-EOF
+# add kobuk PPA
+add_kobuk_ppa
 
 apt install --yes --allow-downgrades \
     linux-image-unsigned-${KERNEL_RELEASE} \

--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -73,7 +73,6 @@ rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 # stop at error
 set -e
 
-# add kobuk PPA
 add_kobuk_ppa
 
 apt install --yes --allow-downgrades \


### PR DESCRIPTION
unattended-upgrade revert back to ubuntu components (qemu, libvirt), we must configure unattended-upgrade to take into consideration our pinning configuration