### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/guest-tools/td_virsh_tool.sh
+++ b/guest-tools/td_virsh_tool.sh
@@ -121,7 +121,8 @@ set_input_paths() {
 }
 
 check_domain_count() {
-    local n_domains_running=$(virsh list --state-running |
+    local n_domains_running
+    n_domains_running=$(virsh list --state-running |
         grep -c ${DOMAIN_PREFIX})
     if [ ${n_domains_running} -ge ${MAX_DOMAINS} ]; then
         echo "Error: exceeded max allowed guests."
@@ -131,7 +132,8 @@ check_domain_count() {
 }
 
 create_overlay_image() {
-    local rand_str=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c15)
+    local rand_str
+    rand_str=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c15)
     overlay_image_path=/tmp/overlay.${rand_str}.qcow2
     qemu-img create \
         -f qcow2 \
@@ -163,13 +165,15 @@ boot_vm() {
 
 echo_ssh_cmd() {
     _domain=$1
-    local host_port=$(
+    local host_port
+    host_port=$(
         virsh \
             qemu-monitor-command ${_domain} \
             --hmp info usernet |
             awk '/HOST_FORWARD/ {print $4}'
     )
-    local guest_cid=$(
+    local guest_cid
+    guest_cid=$(
         virsh \
             qemu-monitor-command ${_domain} \
             --hmp info qtree |
@@ -181,7 +185,8 @@ echo_ssh_cmd() {
 
 destroy() {
     local domain_to_destroy="${1}"
-    local qcow2_overlay_path=$(virsh dumpxml ${domain_to_destroy} |
+    local qcow2_overlay_path
+    qcow2_overlay_path=$(virsh dumpxml ${domain_to_destroy} |
         grep -o "\/tmp\/overlay\.[A-Za-z0-9]*\.qcow2")
 
     echo "Destroying domain ${domain_to_destroy}."

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # use can use -intel kernel by setting TDX_GUEST_SETUP_INTEL_KERNEL
-if [ ! -z "${TDX_GUEST_SETUP_INTEL_KERNEL}" ]; then
+if [ -n "${TDX_GUEST_SETUP_INTEL_KERNEL}" ]; then
    KERNEL_RELEASE=6.8.0-1001-intel
 fi
 
@@ -25,7 +25,7 @@ EOF
 # if not, select the latest generic kernel available on the system
 grub_set_kernel() {
     if [ -z "${KERNEL_RELEASE}" ]; then
-      KERNEL_RELEASE=$(ls /boot/vmlinuz-*-generic 2>&1 | \
+      KERNEL_RELEASE=$(find /boot/vmlinuz-*-generic 2>&1 | \
                       /usr/lib/grub/grub-sort-version -r 2>&1 | \
                       gawk 'match($0 , /^\/boot\/vmlinuz-(.*)/, a) {print a[1];exit}')
     fi
@@ -33,7 +33,7 @@ grub_set_kernel() {
       echo "ERROR : unable to determine kernel release"
       exit 1
     fi
-    grub_switch_kernel ${KERNEL_RELEASE}
+    grub_switch_kernel "${KERNEL_RELEASE}"
 }
 
 apt update
@@ -65,9 +65,9 @@ apt install --yes --allow-downgrades \
 
 # if a specific kernel has to be used instead of generic
 # TODO : install linux-modules-extra
-if [ ! -z "${KERNEL_RELEASE}" ]; then
+if [ -n "${KERNEL_RELEASE}" ]; then
   apt install --yes --allow-downgrades \
-    linux-image-unsigned-${KERNEL_RELEASE}
+    "linux-image-unsigned-${KERNEL_RELEASE}"
 fi
 
 # select the right kernel for next boot
@@ -77,8 +77,8 @@ grub_set_kernel
 # is still in modules-extra only
 # NB: grub_set_kernel updates kernel release that will be used, just check if it is generic
 if [[ "$KERNEL_RELEASE" == *-generic ]]; then
-  apt install --yes linux-modules-extra-${KERNEL_RELEASE}
+  apt install --yes "linux-modules-extra-${KERNEL_RELEASE}"
 fi
 
 # setup attestation
-${SCRIPT_DIR}/attestation/setup-guest.sh
+"${SCRIPT_DIR}"/attestation/setup-guest.sh

--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -37,8 +37,7 @@ EOF
 
 grub_cmdline_kvm() {
   # update cmdline to add tdx=1 to kvm_intel
-  grep -E "GRUB_CMDLINE_LINUX.*=.*\".*kvm_intel.tdx( )*=1.*\"" /etc/default/grub &> /dev/null
-  if [ $? -ne 0 ]; then
+  if ! grep -q -E "GRUB_CMDLINE_LINUX.*=.*\".*kvm_intel.tdx( )*=1.*\"" /etc/default/grub; then
     sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 kvm_intel.tdx=1\"/g" /etc/default/grub
     update-grub
     grub-install
@@ -53,8 +52,7 @@ grub_cmdline_nohibernate() {
   # The kernel uses S3 for suspend-to-ram, and use S4 and deeper states for
   # hibernation.  Currently, for simplicity, the kernel chooses to make TDX
   # mutually exclusive with S3 and hibernation.
-  grep -E "GRUB_CMDLINE_LINUX.*=.*\".*nohibernate.*\"" /etc/default/grub &> /dev/null
-  if [ $? -ne 0 ]; then
+  if ! grep -q -E "GRUB_CMDLINE_LINUX.*=.*\".*nohibernate.*\"" /etc/default/grub; then
     sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 nohibernate\"/g" /etc/default/grub
     update-grub
     grub-install
@@ -94,7 +92,7 @@ grub_cmdline_kvm || true
 grub_cmdline_nohibernate || true
 
 # setup attestation
-${SCRIPT_DIR}/attestation/setup-host.sh
+"${SCRIPT_DIR}"/attestation/setup-host.sh
 
 echo "========================================================================"
 echo "The setup has been done successfully. Please enable now TDX in the BIOS."


### PR DESCRIPTION
Fix shellchecks warnings in setup-tdx* and in guest-tools/td_virsh_tools.sh as they can hide errors.