### PR TITLE
corrections and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,15 +88,9 @@ An example output:
 
 ```
 ...
-[    5.300843] tdx: BIOS enabled: private KeyID range [16, 32)
-[   15.960876] tdx: TDX module: attributes 0x0, vendor_id 0x8086, major_version 1, minor_version 5, build_date 20230323, build_num 481
-[   15.960879] tdx: CMR: [0x100000, 0x77800000)
-[   15.960881] tdx: CMR: [0x100000000, 0x407a000000)
-[   15.960882] tdx: CMR: [0x4080000000, 0x807c000000)
-[   15.960883] tdx: CMR: [0x8080000000, 0xc07c000000)
-[   15.960884] tdx: CMR: [0xc080000000, 0x1007c000000)
-[   18.149996] tdx: 4202516 KBs allocated for PAMT.
-[   18.150000] tdx: module initialized.
+[    5.205693] virt/tdx: BIOS enabled: private KeyID range [64, 128)
+[   29.884504] virt/tdx: 1050644 KB allocated for PAMT
+[   29.884513] virt/tdx: module initialized
 ...
 ```
 <a id="setup-td-guest"></a>

--- a/guest-tools/image/create-td-image.sh
+++ b/guest-tools/image/create-td-image.sh
@@ -199,11 +199,12 @@ EOT
         --virt-type kvm \
         --graphics none \
         --import \
-        --wait=3 &>> $LOGFILE
+        --wait=12 &>> $LOGFILE
     if [ $? -eq 0 ]; then
         ok "Complete cloud-init..."
         sleep 1
     else
+        warn "Please increase wait time(--wait=12) above and try again..."
         error "Failed to configure cloud init"
     fi
 

--- a/guest-tools/run_td.sh
+++ b/guest-tools/run_td.sh
@@ -32,7 +32,7 @@ PROCESS_NAME=td
 QUOTE_ARGS="-device vhost-vsock-pci,guest-cid=3"
 qemu-system-x86_64 -D /tmp/tdx-guest-td.log \
 		   -accel kvm \
-		   -m 2G -smp 64 \
+		   -m 2G -smp 16 \
 		   -name ${PROCESS_NAME},process=${PROCESS_NAME},debug-threads=on \
 		   -cpu host \
 		   -object tdx-guest,id=tdx \

--- a/guest-tools/td_guest.xml.template
+++ b/guest-tools/td_guest.xml.template
@@ -5,7 +5,7 @@
     <source type="anonymous"/>
     <access mode="private"/>
   </memoryBacking>
-  <vcpu placement="static">64</vcpu>
+  <vcpu placement="static">16</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
     <loader>/usr/share/qemu/OVMF.fd</loader>
@@ -27,7 +27,7 @@
     <suspend-to-disk enable='no'/>
   </pm>
   <cpu mode='host-passthrough'>
-    <topology sockets='2' cores='32' threads='1'/>
+    <topology sockets='1' cores='16' threads='1'/>
   </cpu>
   <devices>
     <emulator>/usr/bin/qemu-system-x86_64</emulator>


### PR DESCRIPTION
Reduce the vcpu number of guest to reasonable numbers
TDX does not support multi-sockets for TD so set the socket to 1
Increase timeout for virt-install when creating guest image
README : improve host verification of tdx initialization