### PR TITLE
change kernel installation policy

### DIFF
--- a/setup-tdx-common
+++ b/setup-tdx-common
@@ -28,3 +28,44 @@ Unattended-Upgrade::Allowed-Origins {
 Unattended-Upgrade::Allow-downgrade "true";
 EOF
 }
+
+# get the current kernel version from the kernel flavour/type
+# we are using
+# the input will be the kernel meta package name of type : linux-image-<flavour|type>
+# examples : linux-image-intel, linux-image-generic, linux-image-aws, ...
+get_kernel_version() {
+    local kernel_flavour=$1
+    local kernel_version
+    kernel_version=$(apt show ${kernel_flavour} 2>&1 | gawk 'match($0, /Depends:.* linux-image-([^, ]+)/, a) {print a[1]}')
+    echo $kernel_version
+}
+
+# grub: switch to kernel version
+grub_switch_kernel() {
+    KERNELVER=$1
+    MID=$(awk '/Advanced options for Ubuntu/{print $(NF-1)}' /boot/grub/grub.cfg | cut -d\' -f2)
+    KID=$(awk "/with Linux $KERNELVER/"'{print $(NF-1)}' /boot/grub/grub.cfg | cut -d\' -f2 | head -n1)
+    cat > /etc/default/grub.d/99-tdx-kernel.cfg <<EOF
+GRUB_DEFAULT=saved
+GRUB_SAVEDEFAULT=true
+EOF
+    grub-editenv /boot/grub/grubenv set saved_entry="${MID}>${KID}"
+    update-grub
+}
+
+# select the kernel release for next boot
+# NB : this function will read/write the global variable KERNEL_RELEASE
+# if KERNEL_RELEASE is specified, we use it
+# if not, select the latest generic kernel available on the system and update the KERNEL_RELEASE var
+grub_set_kernel() {
+    if [ -z "${KERNEL_RELEASE}" ]; then
+      KERNEL_RELEASE=$(find /boot/vmlinuz-*-generic 2>&1 | \
+                      /usr/lib/grub/grub-sort-version -r 2>&1 | \
+                      gawk 'match($0 , /^\/boot\/vmlinuz-(.*)/, a) {print a[1];exit}')
+    fi
+    if [ -z "${KERNEL_RELEASE}" ]; then
+      echo "ERROR : unable to determine kernel release"
+      exit 1
+    fi
+    grub_switch_kernel "${KERNEL_RELEASE}"
+}

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -13,7 +13,7 @@ fi
 source ${SCRIPT_DIR}/setup-tdx-common
 
 apt update
-apt install --yes software-properties-common &> /dev/null
+apt install --yes software-properties-common gawk &> /dev/null
 
 # cleanup
 rm -f /etc/apt/preferences.d/kobuk-team-tdx-*

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -2,41 +2,15 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+# the kernel flavour/type we want to use
+KERNEL_TYPE=linux-image-generic
+
 # use can use -intel kernel by setting TDX_GUEST_SETUP_INTEL_KERNEL
 if [ -n "${TDX_GUEST_SETUP_INTEL_KERNEL}" ]; then
-   KERNEL_RELEASE=6.8.0-1001-intel
+  KERNEL_TYPE=linux-image-intel
 fi
 
 source ${SCRIPT_DIR}/setup-tdx-common
-
-# grub: switch to kernel version
-grub_switch_kernel() {
-    KERNELVER=$1
-    MID=$(awk '/Advanced options for Ubuntu/{print $(NF-1)}' /boot/grub/grub.cfg | cut -d\' -f2)
-    KID=$(awk "/with Linux $KERNELVER/"'{print $(NF-1)}' /boot/grub/grub.cfg | cut -d\' -f2 | head -n1)
-    cat > /etc/default/grub.d/99-tdx-kernel.cfg <<EOF
-GRUB_DEFAULT=saved
-GRUB_SAVEDEFAULT=true
-EOF
-    grub-editenv /boot/grub/grubenv set saved_entry="${MID}>${KID}"
-    update-grub
-}
-
-# select the kernel release for next boot
-# if KERNEL_RELEASE is specified, we use it
-# if not, select the latest generic kernel available on the system
-grub_set_kernel() {
-    if [ -z "${KERNEL_RELEASE}" ]; then
-      KERNEL_RELEASE=$(find /boot/vmlinuz-*-generic 2>&1 | \
-                      /usr/lib/grub/grub-sort-version -r 2>&1 | \
-                      gawk 'match($0 , /^\/boot\/vmlinuz-(.*)/, a) {print a[1];exit}')
-    fi
-    if [ -z "${KERNEL_RELEASE}" ]; then
-      echo "ERROR : unable to determine kernel release"
-      exit 1
-    fi
-    grub_switch_kernel "${KERNEL_RELEASE}"
-}
 
 apt update
 apt install --yes software-properties-common &> /dev/null
@@ -53,6 +27,7 @@ apt upgrade --yes
 # install TDX feature
 # install modules-extra to have tdx_guest module
 apt install --yes --allow-downgrades \
+   ${KERNEL_TYPE} \
    shim-signed \
    grub-efi-amd64-signed \
    grub-efi-amd64-bin \
@@ -66,6 +41,7 @@ if [ -n "${KERNEL_RELEASE}" ]; then
     "linux-image-unsigned-${KERNEL_RELEASE}"
 fi
 
+KERNEL_RELEASE=$(get_kernel_version "$KERNEL_TYPE")
 # select the right kernel for next boot
 grub_set_kernel
 


### PR DESCRIPTION
so far, a specific kernel version (6.8.0-1001-intel) is installed and the system will stick to it (when setup script is run again or at system upgrade). we would like to get the latest version of the kernel (for example, when 6.8.0-1002-intel will be released) automatically without having to modify the script.