### PR TITLE
Use kernel flavor in QEMU image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ NOTE: If you're behind a proxy, use `sudo -E` to preserve user environment.
 
 ```bash
 cd tdx/guest-tools/image/
+# create tdx-guest-ubuntu-24.04-generic.qcow2
 sudo ./create-td-image.sh
 ```
 
@@ -119,10 +120,11 @@ The TD guest image uses the Ubuntu generic kernel by default, intel kernel can b
 the environment variable `TDX_GUEST_SETUP_INTEL_KERNEL`.
 
 ```bash
+# create tdx-guest-ubuntu-24.04-intel.qcow2
 sudo TDX_GUEST_SETUP_INTEL_KERNEL=1 ./create-td-image.sh
 ```
 
-The produced TD guest image is `tdx-guest-ubuntu-24.04.qcow2`.
+Note that the kernel type (`generic` or `intel`) is automatically included in the image name so it is easy to distinguish.
 
 The root password is set to `123456`.
 
@@ -163,6 +165,9 @@ cd tdx/guest-tools
 TD_IMG=<path_to_td_qcow2_image> ./run_td.sh
 ```
 
+Without setting TD_IMG the script will default to an image with a generic kernel located at
+`./image/tdx-guest-ubuntu-24.04-generic.qcow2`.
+
 An example output:
 
 ```bash
@@ -191,8 +196,11 @@ systemctl restart libvirtd
 
 ```bash
 cd tdx/guest-tools
-./td_virsh_tool.sh
+TD_IMG=<path_to_td_qcow2_image> ./td_virsh_tool.sh
 ```
+
+Without setting TD_IMG the script will default to an image with a generic kernel located at
+`./image/tdx-guest-ubuntu-24.04-generic.qcow2`.
 
 If you are running the script outside the `tdx/guest-tools` directory, you should set the
 shell variables TD_IMG and/or XML_TEMPLATE to specifiy the paths to the base .qcow2 image

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cd tdx/guest-tools/image/
 sudo ./create-td-image.sh
 ```
 
-The TD guest image uses the Ubuntu generic kernel by default, intel kernel can be selected by using
+The TD guest image uses the Ubuntu generic kernel by default, the intel kernel can be selected by using
 the environment variable `TDX_GUEST_SETUP_INTEL_KERNEL`.
 
 ```bash
@@ -162,11 +162,13 @@ NOTE: It is recommended that you run the script as a non-root user.
 
 ```bash
 cd tdx/guest-tools
-TD_IMG=<path_to_td_qcow2_image> ./run_td.sh
+./run_td.sh
 ```
 
-Without setting TD_IMG the script will default to an image with a generic kernel located at
-`./image/tdx-guest-ubuntu-24.04-generic.qcow2`.
+By default the script will use an image with a generic kernel located at
+`./image/tdx-guest-ubuntu-24.04-generic.qcow2`. A different qcow2
+image (e.g. one with an intel kernel) can be used by setting the TD_IMG
+shell variable.
 
 An example output:
 
@@ -176,7 +178,7 @@ TD VM, PID: 111924, SSH : ssh -p 10022 root@localhost
 
 ### Boot TD Guest with virsh (libvirt)
 
-1. Configure the libvirt.
+1. Configure libvirt
 
 NOTE: It is recommended that you run virsh as a non-root user. To do that, please apply these settings to `/etc/libvirt/qemu.conf`.
 
@@ -196,14 +198,16 @@ systemctl restart libvirtd
 
 ```bash
 cd tdx/guest-tools
-TD_IMG=<path_to_td_qcow2_image> ./td_virsh_tool.sh
+./td_virsh_tool.sh
 ```
 
-Without setting TD_IMG the script will default to an image with a generic kernel located at
-`./image/tdx-guest-ubuntu-24.04-generic.qcow2`.
+By default the script will use an image with a generic kernel located at
+`./image/tdx-guest-ubuntu-24.04-generic.qcow2`. A different qcow2
+image (e.g. one with an intel kernel) can be used by setting the TD_IMG
+shell variable.
 
 If you are running the script outside the `tdx/guest-tools` directory, you should set the
-shell variables TD_IMG and/or XML_TEMPLATE to specifiy the paths to the base .qcow2 image
+shell variables TD_IMG and/or XML_TEMPLATE to specify the paths to the base .qcow2 image
 and the libvirt guest XML template file, respectively. For example:
 
 ```bash
@@ -342,8 +346,8 @@ sudo systemctl status pccs
 ```
 8. Platform registration.
 
-The platformation registration is done with `mpa_registration_tool`, the service is run on system start up,
-registers the platform and gets desactivated. Please check the service does not output any error message:
+The platform registration is done with `mpa_registration_tool`, the service is run on system start up,
+registers the platform and gets deactivated. Please check the service does not output any error message:
 
 ```bash
 sudo systemctl status mpa_registration_tool
@@ -475,7 +479,7 @@ they follow the Ubuntu standards and offer users the same facilities for code so
 
 You can find generic instructions on how to build a package from source here: https://wiki.debian.org/BuildingTutorial
 
-Here are the example intructions for building qemu (for normal user with sudo rights):
+Here are the example instructions for building qemu (for normal user with sudo rights):
 
 1. Install Ubuntu 24.04
 

--- a/guest-tools/image/create-td-image.sh
+++ b/guest-tools/image/create-td-image.sh
@@ -22,7 +22,11 @@ CURR_DIR=$(dirname "$(realpath $0)")
 FORCE_RECREATE=false
 OFFICIAL_UBUNTU_IMAGE=${OFFICIAL_UBUNTU_IMAGE:-"https://cloud-images.ubuntu.com/releases/noble/release/"}
 CLOUD_IMG=${CLOUD_IMG:-"ubuntu-24.04-server-cloudimg-amd64.img"}
-GUEST_IMG="tdx-guest-ubuntu-24.04.qcow2"
+if [[ "${TDX_GUEST_SETUP_INTEL_KERNEL}" == "1" ]]; then
+    GUEST_IMG="tdx-guest-ubuntu-24.04-intel.qcow2"
+else
+    GUEST_IMG="tdx-guest-ubuntu-24.04-generic.qcow2"
+fi
 SIZE=50
 GUEST_USER=${GUEST_USER:-"tdx"}
 GUEST_PASSWORD=${GUEST_PASSWORD:-"123456"}

--- a/guest-tools/run_td.sh
+++ b/guest-tools/run_td.sh
@@ -15,7 +15,7 @@ if [ "$1" = "clean" ]; then
     exit 0
 fi
 
-TD_IMG=${TD_IMG:-${PWD}/image/tdx-guest-ubuntu-24.04.qcow2}
+TD_IMG=${TD_IMG:-${PWD}/image/tdx-guest-ubuntu-24.04-generic.qcow2}
 TDVF_FIRMWARE=/usr/share/ovmf/OVMF.fd
 
 if ! groups | grep -qw "kvm"; then

--- a/guest-tools/td_virsh_tool.sh
+++ b/guest-tools/td_virsh_tool.sh
@@ -63,7 +63,7 @@ Available options:
 
 Environment variables:
 
-TD_IMG         TDX image path (default: ./image/tdx-guest-ubuntu-24.04.qcow2)
+TD_IMG         TDX image path (default: ./image/tdx-guest-ubuntu-24.04-generic.qcow2)
 XML_TEMPLATE   Path to virsh guest XML template (default: ./td_guest.xml.template)
 MAX_DOMAINS    Maximum allowed domains running (default: 20)
 EOM

--- a/guest-tools/td_virsh_tool.sh
+++ b/guest-tools/td_virsh_tool.sh
@@ -11,7 +11,7 @@
 #
 DOMAIN_PREFIX="td_guest"
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-BASE_IMG=${TD_IMG:-${SCRIPT_DIR}/image/tdx-guest-ubuntu-24.04.qcow2}
+BASE_IMG=${TD_IMG:-${SCRIPT_DIR}/image/tdx-guest-ubuntu-24.04-generic.qcow2}
 XML_TEMPLATE=${XML_TEMPLATE:-${SCRIPT_DIR}/td_guest.xml.template}
 MAX_DOMAINS=${MAX_DOMAINS:-"20"}
 


### PR DESCRIPTION
Addresses https://github.com/canonical/tdx/issues/72

# Testing

System: right-glider

## Image creation

```bash
$ # create generic image
$ sudo ./create-td-image.sh
.
.
$ ls *.qcow2
tdx-guest-ubuntu-24.04-generic.qcow2
 
$ # create intel image
$ sudo TDX_GUEST_SETUP_INTEL_KERNEL=1 ./create-td-image.sh  
.
.
$ ls *.qcow2
tdx-guest-ubuntu-24.04-generic.qcow2  tdx-guest-ubuntu-24.04-intel.qcow2
```

## QEMU guest script

```bash
$ # run TD with default generic kernel
$ ./run_td.sh   
TD VM, PID: 3867045, SSH : ssh -p 10022 root@localhost
$ ssh -p 10022 root@localhost "lsb_release -a; uname -r; dmesg | grep -i tdx"
.
.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04 LTS
Release:	24.04
Codename:	noble
6.8.0-31-generic
[    0.000000] tdx: Guest detected
[    0.558487] process: using TDX aware idle routine
[    0.641704] Memory Encryption Features active: Intel TDX
[   28.198489] systemd[1]: Detected confidential virtualization tdx.
[   28.210481] systemd[1]: Hostname set to <tdx-guest>.

$ # run TD with intel kernel
$ TD_IMG=./image/tdx-guest-ubuntu-24.04-intel.qcow2 ./run_td.sh  
TD VM, PID: 3871320, SSH : ssh -p 10022 root@localhost
$ ssh -p 10022 root@localhost "lsb_release -a; uname -r; dmesg | grep -i tdx"
.
.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04 LTS
Release:	24.04
Codename:	noble
6.8.0-1001-intel
[    0.000000] tdx: Guest detected
[    0.551586] process: using TDX aware idle routine
[    0.629059] Memory Encryption Features active: Intel TDX
[   27.533757] systemd[1]: Detected confidential virtualization tdx.
[   27.546752] systemd[1]: Hostname set to <tdx-guest>.

```

## Libvirt guest script

```bash
$ # create TD with generic kernel
$ ./td_virsh_tool.sh
Domain td_guest-d9e04f7c-d6c0-408c-9e25-fda92b60f2c5 running with vsock CID: 3, ssh -p 39707 root@localhost
$ # check guest with generic kernel
$ ssh -p 39707 root@localhost "lsb_release -a; uname -r; dmesg | grep -i tdx"
.
.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04 LTS
Release:	24.04
Codename:	noble
6.8.0-31-generic
[    0.000000] tdx: Guest detected
[    0.513463] process: using TDX aware idle routine
[    0.593465] Memory Encryption Features active: Intel TDX
[   28.623583] systemd[1]: Detected confidential virtualization tdx.
[   28.639678] systemd[1]: Hostname set to <tdx-guest>.


$ # create TD with intel kernel
$ TD_IMG=./image/tdx-guest-ubuntu-24.04-intel.qcow2 ./td_virsh_tool.sh
Domain td_guest-2fdbbf57-7d38-4074-a859-bd57f3a61908 running with vsock CID: 4, ssh -p 38973 root@localhost
$ # check guest with intel kernel
$ ssh -p 38973 root@localhost "lsb_release -a; uname -r; dmesg | grep -i tdx"
.
.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04 LTS
Release:	24.04
Codename:	noble
6.8.0-1001-intel
[    0.000000] tdx: Guest detected
[    0.531768] process: using TDX aware idle routine
[    0.611051] Memory Encryption Features active: Intel TDX
[   30.438518] systemd[1]: Detected confidential virtualization tdx.
[   30.456611] systemd[1]: Hostname set to <tdx-guest>.
```



