### PR TITLE
run_td.sh: add hpet=off

### DIFF
--- a/guest-tools/run_td.sh
+++ b/guest-tools/run_td.sh
@@ -36,7 +36,7 @@ qemu-system-x86_64 -D /tmp/tdx-guest-td.log \
 		   -name ${PROCESS_NAME},process=${PROCESS_NAME},debug-threads=on \
 		   -cpu host \
 		   -object tdx-guest,id=tdx \
-		   -machine q35,kernel_irqchip=split,confidential-guest-support=tdx \
+		   -machine q35,kernel_irqchip=split,confidential-guest-support=tdx,hpet=off \
 		   -bios ${TDVF_FIRMWARE} \
 		   -nographic -daemonize \
 		   -nodefaults \


### PR DESCRIPTION
Recommend to use tsc as the clocksource in TD guest and not to use hpet. Without hpet=off, the default clocksource in TD guest is also tsc, but the users can change the closcksouce by themselves. So we disable hpet in qemu para to ensure hpet will not be used in TD guest.