### PR TITLE
Add configuration variable to allow to switch TDX PPA

### DIFF
--- a/setup-tdx-common
+++ b/setup-tdx-common
@@ -10,12 +10,13 @@
 # in case the packages in the PPA have older versions than the ones
 # from Ubuntu archive
 add_kobuk_ppa() {
-  distro_id=LP-PPA-kobuk-team-tdx-release
+  ppa_id=$1
+  distro_id=LP-PPA-kobuk-team-${ppa_id}
   distro_codename=noble
 
-  add-apt-repository -y ppa:kobuk-team/tdx-release
+  add-apt-repository -y ppa:kobuk-team/${ppa_id}
 
-  cat <<EOF | tee /etc/apt/preferences.d/kobuk-team-tdx-release-pin-4000
+  cat <<EOF | tee /etc/apt/preferences.d/kobuk-team-${ppa_id}-pin-4000
 Package: *
 Pin: release o=${distro_id}
 Pin-Priority: 4000

--- a/setup-tdx-config
+++ b/setup-tdx-config
@@ -3,6 +3,13 @@
 ################################################################
 
 ################################################################
+# The TDX PPA to use
+# By default, this is the release PPA
+# but for development purpose, users can switch to dev PPA: tdx
+################################################################
+TDX_PPA=tdx-release
+
+################################################################
 # Enable the installation of DCAP packages from Canonical's
 # repository. This flag is considered during host OS and guest
 # OS setup.

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -24,7 +24,7 @@ apt install --yes software-properties-common gawk &> /dev/null
 rm -f /etc/apt/preferences.d/kobuk-team-tdx-*
 rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 
-add_kobuk_ppa
+add_kobuk_ppa ${TDX_PPA:-tdx}
 
 # upgrade the system to have the latest components (mostly generic kernel)
 apt upgrade --yes

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -24,7 +24,7 @@ apt install --yes software-properties-common gawk &> /dev/null
 rm -f /etc/apt/preferences.d/kobuk-team-tdx-*
 rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 
-add_kobuk_ppa ${TDX_PPA:-tdx}
+add_kobuk_ppa ${TDX_PPA:-tdx-release}
 
 # upgrade the system to have the latest components (mostly generic kernel)
 apt upgrade --yes

--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -74,7 +74,7 @@ rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 # stop at error
 set -e
 
-add_kobuk_ppa ${TDX_PPA:-tdx}
+add_kobuk_ppa ${TDX_PPA:-tdx-release}
 
 apt install --yes --allow-downgrades \
     ${KERNEL_TYPE} \

--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -74,7 +74,7 @@ rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 # stop at error
 set -e
 
-add_kobuk_ppa
+add_kobuk_ppa ${TDX_PPA:-tdx}
 
 apt install --yes --allow-downgrades \
     ${KERNEL_TYPE} \


### PR DESCRIPTION
The PPA used for tdx packages is tdx-release.
For development purpose, we might want to switch back to the dev PPA (tdx). Add a variable in the config file for that.