### PR TITLE
Detect and fix platform registration failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ sudo ./check-production.sh
 		Apr 09 22:54:50 right-glider-515046 systemd[1]: Started mpa_registration_tool.service - Intel MPA Registratio>
 		Apr 09 22:54:50 right-glider-515046 systemd[1]: mpa_registration_tool.service: Deactivated successfully.
 		```
-	2. Check plateform registration logs with following command:
+	2. Check MPA log file with following command:
 		```bash
 		cat /var/log/mpa_registration.log
 		```

--- a/README.md
+++ b/README.md
@@ -406,8 +406,8 @@ sudo ./check-production.sh
 	[04-06-2024 03:05:54] INFO: Finished Registration Agent Flow.
     ```
 
-	If the failure occurred, you might want to boot into the BIOS and Go to 
-	`Socket Configuration > Processor Configuration > Software Guard Extension (SGX)` and Set
+	If an error is reported in one of the logs, boot into the BIOS, go to 
+	`Socket Configuration > Processor Configuration > Software Guard Extension (SGX)`, and set
 	- `SGX Factory Reset` to `Enabled`
 	- `SGX Auto MP Registration` to `Enabled`
 

--- a/README.md
+++ b/README.md
@@ -377,34 +377,40 @@ sudo ./check-production.sh
 
 	The platform registration is done with the `mpa_registration_tool` tool.
 	This service is executed on system start up, registers the platform, and gets deactivated.
-	Please check the service does not output any error message:
+	Please check the following two logs to confirm successful registration:
 
-	```bash
-	sudo systemctl status mpa_registration_tool
-	```
+	1. Check service logs with following command:
 
-	An example output:
+		```bash
+		sudo systemctl status mpa_registration_tool
+		```
 
-	```bash
-	mpa_registration_tool.service - Intel MPA Registration
-		Loaded: loaded (/usr/lib/systemd/system/mpa_registration_tool.service; enabled; preset: enabled)
-		Active: inactive (dead) since Tue 2024-04-09 22:54:50 UTC; 11h ago
-	Duration: 46ms
-	Main PID: 3409 (code=exited, status=0/SUCCESS)
-			CPU: 21ms
+		An example output:
 
-	Apr 09 22:54:50 right-glider-515046 systemd[1]: Started mpa_registration_tool.service - Intel MPA Registratio>
-	Apr 09 22:54:50 right-glider-515046 systemd[1]: mpa_registration_tool.service: Deactivated successfully.
-	```
-	Also file `/var/log/mpa_registration.log` is expected to have below logs for
-	successful `Platform registration`:
+		```bash
+		mpa_registration_tool.service - Intel MPA Registration
+			Loaded: loaded (/usr/lib/systemd/system/mpa_registration_tool.service; enabled; preset: enabled)
+			Active: inactive (dead) since Tue 2024-04-09 22:54:50 UTC; 11h ago
+		Duration: 46ms
+		Main PID: 3409 (code=exited, status=0/SUCCESS)
+				CPU: 21ms
 
-	```bash
-	[04-06-2024 03:05:53] INFO: SGX Registration Agent version: 1.20.100.2
-	[04-06-2024 03:05:53] INFO: Starts Registration Agent Flow.
-	[04-06-2024 03:05:54] INFO: Registration Flow - PLATFORM_ESTABLISHMENT or TCB_RECOVERY passed successfully.
-	[04-06-2024 03:05:54] INFO: Finished Registration Agent Flow.
-    ```
+		Apr 09 22:54:50 right-glider-515046 systemd[1]: Started mpa_registration_tool.service - Intel MPA Registratio>
+		Apr 09 22:54:50 right-glider-515046 systemd[1]: mpa_registration_tool.service: Deactivated successfully.
+		```
+	2. Check plateform registration logs with following command:
+		```bash
+		cat /var/log/mpa_registration.log
+		```
+
+		An example output:
+
+		```bash
+		[04-06-2024 03:05:53] INFO: SGX Registration Agent version: 1.20.100.2
+		[04-06-2024 03:05:53] INFO: Starts Registration Agent Flow.
+		[04-06-2024 03:05:54] INFO: Registration Flow - PLATFORM_ESTABLISHMENT or TCB_RECOVERY passed successfully.
+		[04-06-2024 03:05:54] INFO: Finished Registration Agent Flow.
+		```
 
 	If an error is reported in one of the logs, boot into the BIOS, go to 
 	`Socket Configuration > Processor Configuration > Software Guard Extension (SGX)`, and set

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ sudo ./check-production.sh
 		cat /var/log/mpa_registration.log
 		```
 
-		An example output:
+		A successful example output:
 
 		```bash
 		[04-06-2024 03:05:53] INFO: SGX Registration Agent version: 1.20.100.2

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ sudo ./check-production.sh
 		sudo systemctl status mpa_registration_tool
 		```
 
-		An example output:
+		A successful example output:
 
 		```bash
 		mpa_registration_tool.service - Intel MPA Registration

--- a/README.md
+++ b/README.md
@@ -396,10 +396,20 @@ sudo ./check-production.sh
 	Apr 09 22:54:50 right-glider-515046 systemd[1]: Started mpa_registration_tool.service - Intel MPA Registratio>
 	Apr 09 22:54:50 right-glider-515046 systemd[1]: mpa_registration_tool.service: Deactivated successfully.
 	```
+	Also file `/var/log/mpa_registration.log` is expected to have below logs for
+	successful `Platform registration`:
 
-	If the failure occurred, you might want to boot into the BIOS and perform an Intel SGX Factory reset.
-	This can be done by selecting `SGX Factory Reset` in `Socket Configuration > Processor Configuration`.
+	```bash
+	[04-06-2024 03:05:53] INFO: SGX Registration Agent version: 1.20.100.2
+	[04-06-2024 03:05:53] INFO: Starts Registration Agent Flow.
+	[04-06-2024 03:05:54] INFO: Registration Flow - PLATFORM_ESTABLISHMENT or TCB_RECOVERY passed successfully.
+	[04-06-2024 03:05:54] INFO: Finished Registration Agent Flow.
+    ```
 
+	If the failure occurred, you might want to boot into the BIOS and Go to 
+	`Socket Configuration > Processor Configuration > Software Guard Extension (SGX)` and Set
+	- `SGX factory reset` to `Enabled`
+	- `SGX Auto MP Registration` to `Enabled`
 
 ### 8.3 Setup [Intel Tiber Trust Services CLI](https://github.com/intel/trustauthority-client-for-go) inside TD
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ sudo ./check-production.sh
 
 	If the failure occurred, you might want to boot into the BIOS and Go to 
 	`Socket Configuration > Processor Configuration > Software Guard Extension (SGX)` and Set
-	- `SGX factory reset` to `Enabled`
+	- `SGX Factory Reset` to `Enabled`
 	- `SGX Auto MP Registration` to `Enabled`
 
 ### 8.3 Setup [Intel Tiber Trust Services CLI](https://github.com/intel/trustauthority-client-for-go) inside TD


### PR DESCRIPTION
This PR add info to main README to detect and fix [Platform registration](https://github.com/canonical/tdx/blob/a8261b15784a5bd9962bbc5af63d27444b8bbb3c/README.md?plain=1#L376) failures.

Fixes #131

