### PR TITLE
Fixing up checkbox tests to run same tests as pytest

### DIFF
--- a/tests/checkbox/bin/checkbox-cli-wrapper
+++ b/tests/checkbox/bin/checkbox-cli-wrapper
@@ -2,4 +2,4 @@
 
 # wrapper around the checkbox-cli
 # use absolute path in order to not use system checkbox-cli (from deb packages)
-exec /snap/checkbox22/current/bin/checkbox-cli "$@"
+exec /snap/bin/checkbox.checkbox-cli "$@"

--- a/tests/checkbox/checkbox-provider-tdx/units/basic/jobs.pxu
+++ b/tests/checkbox/checkbox-provider-tdx/units/basic/jobs.pxu
@@ -7,7 +7,7 @@ depends:
 after:
 requires:
 command:
-  test_host_tdx_hardware.py
+  setup-env-and-run test_host_tdx_hardware.py
 
 id: tdx-basic/tdx-module-check
 category_id: tdx-basic
@@ -19,7 +19,7 @@ depends:
 after:
 requires:
 command:
-  test_host_tdx_software.py
+  setup-env-and-run test_host_tdx_software.py
 
 id: tdx-basic/qemu-basic-td-creation
 category_id: tdx-basic
@@ -45,7 +45,7 @@ requires:
   executable.name == 'qemu-system-x86_64'
 command:
   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  test_boot.py
+  setup-env-and-run test_boot_basic.py
 
 id: tdx-basic/td-coexist
 category_id: tdx-basic
@@ -57,7 +57,7 @@ requires:
   executable.name == 'qemu-system-x86_64'
 command:
   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  test_coexist.py
+  setup-env-and-run test_boot_coexist.py
 
 id: tdx-basic/td-creation
 category_id: tdx-basic
@@ -69,7 +69,7 @@ requires:
   executable.name == 'qemu-system-x86_64'
 command:
   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  test_td_creation.py
+  setup-env-and-run test_boot_td_creation.py
 
 id: tdx-basic/td-creation-multiple
 category_id: tdx-basic
@@ -81,7 +81,7 @@ requires:
   executable.name == 'qemu-system-x86_64'
 command:
   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  test_multiple_vms.py
+  setup-env-and-run test_boot_multiple_vms.py
 
 id: tdx-basic/td-measurement
 category_id: tdx-basic
@@ -93,7 +93,8 @@ requires:
   executable.name == 'qemu-system-x86_64'
 command:
   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  test_measurement.py
+  setup-env-and-run test_guest_measurement.py
+
 
 # id: tdx-basic/perf-boot-time
 # category_id: tdx-basic

--- a/tests/pytest/setup-env-and-run
+++ b/tests/pytest/setup-env-and-run
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+RUN_FOLDER=/var/tmp/tdxtest/
+CHECKBOX_FOLDER=/var/tmp/checkbox-providers/checkbox-provider-tdx/
+
+setup_venv() {
+  mkdir -p ${RUN_FOLDER}
+  python3 -m venv ${RUN_FOLDER}/venv
+  source ${RUN_FOLDER}/venv/bin/activate
+  python3 -m pip install paramiko==3.3.1 \
+	  pytest==8.2.1 \
+	  parameterized==0.9.0 \
+	  py-cpuinfo==9.0.0
+
+  (cd ${CHECKBOX_FOLDER}/lib/tdx-tools/ && python3 -m pip install ./)
+}
+
+deactivate &> /dev/null || true
+if [ ! -d ${RUN_FOLDER}/venv ]; then
+  setup_venv &> /dev/null
+else
+  source ${RUN_FOLDER}/venv/bin/activate
+fi
+
+export PYTHONPATH=${PYTHONPATH}:${CHECKBOX_FOLDER}/lib
+python3 ${CHECKBOX_FOLDER}/bin/$1

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -41,6 +41,9 @@ if [ -z "${TDXTEST_IMAGE_FILE}" ]; then
 	_error "Should specify a guest image by setting TDXTEST_IMAGE_FILE"
     fi
 fi
+
+rm -rf /var/tmp/tdxtest
+mkdir -p /var/tmp/tdxtest
 cp ${TDXTEST_IMAGE_FILE} $IMAGE_FILE &> /dev/null
 
 if [ ! -f $IMAGE_FILE ]; then

--- a/tests/run_checkbox
+++ b/tests/run_checkbox
@@ -3,9 +3,6 @@
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 CHECKBOX_DIR=${SCRIPT_DIR}/checkbox
 
-echo "Not supported yet"
-exit 1
-
 install_deps() {
 		sudo snap install checkbox22 &> /de
 		sudo snap install checkbox --classic
@@ -14,9 +11,11 @@ install_deps() {
 install_deps &> /dev/null
 
 rm -rf /var/tmp/checkbox-providers/checkbox-provider-tdx/
+mkdir -p /var/tmp/checkbox-providers
 cp -rf ${CHECKBOX_DIR}/checkbox-provider-tdx /var/tmp/checkbox-providers/
-cp -rf ${SCRIPT_DIR}/bin /var/tmp/checkbox-providers/checkbox-provider-tdx
+cp -rf ${SCRIPT_DIR}/pytest /var/tmp/checkbox-providers/checkbox-provider-tdx/bin
 cp -rf ${SCRIPT_DIR}/lib /var/tmp/checkbox-providers/checkbox-provider-tdx
+chmod a+x /var/tmp/checkbox-providers/checkbox-provider-tdx/bin/*
 
 # run checkbox in side-provider mode and use the host system python3 libraries
 # checkbox comes with its own python libs and runtime (see checkbox22)


### PR DESCRIPTION
This is a first step for internal JIRA PEK-710.  This is to get checkbox working with the existing set of tests.  Next steps:
* Add the rest of the pytests
* Cleanup documentation and directories to align with pytests and new checkbox implementations
* Verify consistency of testing