### PR TITLE
Adding all pytests to checkbox list for PEK-710

### DIFF
--- a/tests/checkbox/checkbox-provider-tdx/units/basic/jobs.pxu
+++ b/tests/checkbox/checkbox-provider-tdx/units/basic/jobs.pxu
@@ -83,6 +83,18 @@ command:
   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
   setup-env-and-run test_boot_multiple_vms.py
 
+id: tdx-basic/td-stress-boot
+category_id: tdx-basic
+flags: simple
+_summary: Test boot stress
+depends:
+after:
+requires:
+  executable.name == 'qemu-system-x86_64'
+command:
+  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  setup-env-and-run test_stress_boot.py
+
 id: tdx-basic/td-measurement
 category_id: tdx-basic
 flags: simple
@@ -95,15 +107,75 @@ command:
   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
   setup-env-and-run test_guest_measurement.py
 
+id: tdx-basic/td-guest-reboot
+category_id: tdx-basic
+flags: simple
+_summary: Test guest reboot
+depends:
+after:
+requires:
+  executable.name == 'qemu-system-x86_64'
+command:
+  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  setup-env-and-run test_guest_reboot.py
 
-# id: tdx-basic/perf-boot-time
-# category_id: tdx-basic
-# flags: simple
-# _summary: Measure boot time
-# depends:
-# after:
-# requires:
-#   executable.name == 'qemu-system-x86_64'
-# command:
-#   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-#   perf_boot_time.py
+id: tdx-basic/td-guest-report
+category_id: tdx-basic
+flags: simple
+_summary: Test guest report
+depends:
+after:
+requires:
+  executable.name == 'qemu-system-x86_64'
+command:
+  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  setup-env-and-run test_guest_report.py
+
+id: tdx-basic/td-guest-eventlog
+category_id: tdx-basic
+flags: simple
+_summary: Test guest eventlog
+depends:
+after:
+requires:
+  executable.name == 'qemu-system-x86_64'
+command:
+  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  setup-env-and-run test_guest_eventlog.py
+
+id: tdx-basic/td-perf-benchmark
+category_id: tdx-basic
+flags: simple
+_summary: Test perf benchmark
+depends:
+after:
+requires:
+  executable.name == 'qemu-system-x86_64'
+command:
+  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  setup-env-and-run test_perf_benchmark.py
+
+id: tdx-basic/td-perf-boot-time
+category_id: tdx-basic
+flags: simple
+_summary: Test perf boot-time
+depends:
+after:
+requires:
+  executable.name == 'qemu-system-x86_64'
+command:
+  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  setup-env-and-run test_perf_boot_time.py
+
+id: tdx-basic/td-quote-configfs-tsm
+category_id: tdx-basic
+flags: simple
+_summary: Test quote configfs tsm
+depends:
+after:
+requires:
+  executable.name == 'qemu-system-x86_64'
+command:
+  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  setup-env-and-run test_quote_configfs_tsm.py
+

--- a/tests/checkbox/checkbox-provider-tdx/units/basic/jobs.pxu
+++ b/tests/checkbox/checkbox-provider-tdx/units/basic/jobs.pxu
@@ -143,17 +143,17 @@ command:
   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
   setup-env-and-run test_guest_eventlog.py
 
-id: tdx-basic/td-perf-benchmark
-category_id: tdx-basic
-flags: simple
-_summary: Test perf benchmark
-depends:
-after:
-requires:
-  executable.name == 'qemu-system-x86_64'
-command:
-  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-  setup-env-and-run test_perf_benchmark.py
+#id: tdx-basic/td-perf-benchmark
+#category_id: tdx-basic
+#flags: simple
+#_summary: Test perf benchmark
+#depends:
+#after:
+#requires:
+#  executable.name == 'qemu-system-x86_64'
+#command:
+#  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+#  setup-env-and-run test_perf_benchmark.py
 
 id: tdx-basic/td-perf-boot-time
 category_id: tdx-basic

--- a/tests/pytest/setup-env-and-run
+++ b/tests/pytest/setup-env-and-run
@@ -5,6 +5,8 @@ CHECKBOX_FOLDER=/var/tmp/checkbox-providers/checkbox-provider-tdx/
 
 setup_venv() {
   mkdir -p ${RUN_FOLDER}
+  mkdir -p ${RUN_FOLDER}/reports
+  chmod a+w ${RUN_FOLDER}/reports
   python3 -m venv ${RUN_FOLDER}/venv
   source ${RUN_FOLDER}/venv/bin/activate
   python3 -m pip install paramiko==3.3.1 \
@@ -23,4 +25,8 @@ else
 fi
 
 export PYTHONPATH=${PYTHONPATH}:${CHECKBOX_FOLDER}/lib
-python3 ${CHECKBOX_FOLDER}/bin/$1
+
+# TODO: -rP, -rE : print test output on Passed and Error
+# -s : do not capture logs
+# -v : increase verbosity
+python3 -m pytest -s -v --junitxml=${RUN_FOLDER}/reports/$1_report.xml ${CHECKBOX_FOLDER}/bin/$1

--- a/tests/pytest/test_guest_measurement.py
+++ b/tests/pytest/test_guest_measurement.py
@@ -40,18 +40,3 @@ def test_guest_measurement_check_rtmr():
 
     qm.stop()
 
-def test_guest_measurement_check_rtmr():
-    """
-    Boot measurements check
-    """
-    qm = Qemu.QemuMachine()
-    qm.run()
-
-    m = Qemu.QemuSSH(qm)
-    m.rsync_file(f'{script_path}/../lib', '/tmp/tdxtest/')
-    m.check_exec('cd /tmp/tdxtest/lib/tdx-tools/ && python3 -m pip install --break-system-packages ./')
-
-    m.check_exec('tdrtmrcheck')
-
-    qm.stop()
-

--- a/tests/run_checkbox
+++ b/tests/run_checkbox
@@ -22,3 +22,6 @@ chmod a+x /var/tmp/checkbox-providers/checkbox-provider-tdx/bin/*
 # check the requirement
 
 PATH=$PATH:${CHECKBOX_DIR}/bin ${CHECKBOX_DIR}/bin/test-runner-automated
+
+# Reports for checkbox get put here
+echo "Reports can be found at /var/tmp/tdxtest/reports"


### PR DESCRIPTION
All tests available were added.  Put reports generated into /var/tmp/tdxtest/reports (as checkbox calls pytest).

Removed td-perf-benchmark as it doesn't seem to complete after several hours.  Will resolve later.

This is a continuation of other PEK-710 pull request.