### PR TITLE
PEK-710 - fix snap build

### DIFF
--- a/tests/snap/snapcraft.yaml
+++ b/tests/snap/snapcraft.yaml
@@ -83,7 +83,7 @@ parts:
       checkbox-provider-tools install --layout=relocatable --prefix=/providers/checkbox-provider-tdx --root="$SNAPCRAFT_PART_INSTALL"
   provider-bin:
     plugin: dump
-    source: bin
+    source: pytest
     organize:
       '*': providers/checkbox-provider-tdx/bin/
   lib:


### PR DESCRIPTION
Simple fix for the snap builds.  More work in future pulse to deal with where the guest qcow2 image gets referenced.