### PR TITLE
licence: fix shebangs and licence

### DIFF
--- a/attestation/check-production.sh
+++ b/attestation/check-production.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This file is part of Canonical's TDX repository which includes tools
 # to setup and configure a confidential computing environment
 # based on Intel TDX technology.
@@ -13,8 +15,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranties
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
-
-#!/bin/bash
 
 if [ "$EUID" -ne 0 ]
   then echo "Please run as root"

--- a/attestation/setup-attestation-guest.sh
+++ b/attestation/setup-attestation-guest.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This file is part of Canonical's TDX repository which includes tools
 # to setup and configure a confidential computing environment
 # based on Intel TDX technology.
@@ -13,8 +15,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranties
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
-
-#!/bin/bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/attestation/setup-attestation-host.sh
+++ b/attestation/setup-attestation-host.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This file is part of Canonical's TDX repository which includes tools
 # to setup and configure a confidential computing environment
 # based on Intel TDX technology.
@@ -14,8 +16,6 @@
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
 
-#!/bin/bash
-#
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ "$EUID" -ne 0 ]

--- a/guest-tools/image/create-td-image.sh
+++ b/guest-tools/image/create-td-image.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+#
+
 # This source code is a modified copy of https://github.com/intel/tdx-tools.git
 # See LICENSE.apache file for original license information.
 
@@ -16,9 +19,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranties
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
-
-#!/bin/bash
-#
 
 # This script will create a TDX guest image (qcow2 format) from a cloud
 # image that is released at : https://cloud-images.ubuntu.com

--- a/guest-tools/image/setup.sh
+++ b/guest-tools/image/setup.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
+
 # Copyright (C) 2024 Canonical Ltd.
 #
 # This file is part of tdx repo. See LICENSE file for license information.
-
-#!/bin/bash
 
 apt update
 

--- a/guest-tools/run_td.sh
+++ b/guest-tools/run_td.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This file is part of Canonical's TDX repository which includes tools
 # to setup and configure a confidential computing environment
 # based on Intel TDX technology.
@@ -14,7 +16,6 @@
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
 
-#!/bin/bash
 
 cleanup() {
     rm -f /tmp/tdx-guest-*.log &> /dev/null

--- a/guest-tools/tdvirsh
+++ b/guest-tools/tdvirsh
@@ -1,3 +1,8 @@
+#!/bin/bash
+#
+# Wrapper around virsh to ease the creation of TDs
+#
+
 # This file is part of Canonical's TDX repository which includes tools
 # to setup and configure a confidential computing environment
 # based on Intel TDX technology.
@@ -13,11 +18,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranties
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
-
-#!/bin/bash
-#
-# Wrapper around virsh to ease the creation of TDs
-#
 
 ##
 # Global constants

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This file is part of Canonical's TDX repository which includes tools
 # to setup and configure a confidential computing environment
 # based on Intel TDX technology.
@@ -13,8 +15,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranties
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
-
-#!/bin/bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This file is part of Canonical's TDX repository which includes tools
 # to setup and configure a confidential computing environment
 # based on Intel TDX technology.
@@ -13,8 +15,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranties
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
-
-#!/bin/bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This file is part of Canonical's TDX repository which includes tools
 # to setup and configure a confidential computing environment
 # based on Intel TDX technology.
@@ -13,8 +15,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranties
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
-
-#!/bin/bash
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 

--- a/tests/run_pytest
+++ b/tests/run_pytest
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This file is part of Canonical's TDX repository which includes tools
 # to setup and configure a confidential computing environment
 # based on Intel TDX technology.
@@ -13,8 +15,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranties
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
-
-#!/bin/bash
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 


### PR DESCRIPTION
Shebangx needs to be on the first line of the file to be effective. Move back all license notice after the shebang.