### PR TITLE
Pek 743 create github action for snap build on repo push

### DIFF
--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -19,7 +19,7 @@ jobs:
           cd tests
           # run snapcraft in destructive mode 
           # -- network doesn't work properly otherwise
-          sudo snapcraft --destructive-mode
+          sudo snapcraft
       - name: Output logs step
         if: always()
         run: |

--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -3,17 +3,15 @@ run-name: ${{ github.actor }} is creating testing snap
 on: [push]
 jobs:
   Create-Snap-Action:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
       - name: Check out repository code step
         uses: actions/checkout@v4
       - name: Installation step
         run: |
-          sudo apt update
-          sudo apt install snapcraft
+          sudo snap install snapcraft --classic
           sudo snap install lxd
-          sudo snap install core24
           sudo lxd init --auto
           sudo lxd waitready
       - name: Run snapcraft step

--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -15,6 +15,7 @@ jobs:
           sudo snap install lxd
           sudo snap install core24
           sudo lxd init --auto
+          sudo lxd waitready
       - name: Run snapcraft step
         run: | 
           cd tests

--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: 
       - main
-      - pek_743_create_snap_action
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -4,7 +4,9 @@ run-name: ${{ github.actor }} is creating testing snap
 
 on:
   push:
-    branches: [ "main" ]
+    branches: 
+      - main
+      - pek_743_create_snap_action
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -1,27 +1,28 @@
-name: Create snap action
+name: Do a snap build
+
 run-name: ${{ github.actor }} is creating testing snap
-on: [push]
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch: # Allow manual trigger
+
 jobs:
-  Create-Snap-Action:
-    runs-on: ubuntu-24.04
-    continue-on-error: true
+
+  build:
+    runs-on: ubuntu-22.04
     steps:
-      - name: Check out repository code step
-        uses: actions/checkout@v4
-      - name: Installation step
+      - uses: actions/checkout@v4
+        name: Checkout
+
+      - uses: snapcore/action-build@v1
+        name: Build snap
+        id: build
+        with:
+          path: tests
+          snapcraft-channel: latest/stable
+
+      - name: Verify snap
         run: |
-          sudo snap install snapcraft --classic
-          sudo snap install lxd
-          sudo lxd init --auto
-          sudo lxd waitready
-      - name: Run snapcraft step
-        run: | 
-          cd tests
-          # run snapcraft in destructive mode 
-          # -- network doesn't work properly otherwise
-          sudo snapcraft --destructive
-      - name: Output logs step
-        if: always()
-        run: |
-          journalctl -u snap.lxd.daemon
-          sudo bash -c 'cat /root/.local/state/snapcraft/log/snapcraft*.log'
+          sudo snap install checkbox22
+          sudo snap install --dangerous --classic ${{ steps.build.outputs.snap }}

--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -1,0 +1,30 @@
+name: Create snap action
+run-name: ${{ github.actor }} is creating testing snap
+on: [push]
+jobs:
+  Create-Snap-Action:
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Installation Step
+        run: |
+          echo "Install snapcraft"
+          sudo apt update
+          sudo apt install snapcraft
+          echo "Install snapcraft"
+          sudo snap install lxd
+          echo "Initialize snapcraft"
+          sudo lxd init --auto
+      - name: Run snapcraft
+        run: | 
+          cd tests
+          # run snapcraft in destructive mode 
+          # -- network doesn't work properly otherwise
+          sudo snapcraft --destructive-mode
+      - name: Output logs
+        if: always()
+        run: |
+          journalctl -u snap.multipass.multipassd
+          sudo bash -c 'cat /root/.local/state/snapcraft/log/snapcraft*.log'

--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -3,7 +3,7 @@ run-name: ${{ github.actor }} is creating testing snap
 on: [push]
 jobs:
   Create-Snap-Action:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - name: Check out repository code step
@@ -19,7 +19,7 @@ jobs:
           cd tests
           # run snapcraft in destructive mode 
           # -- network doesn't work properly otherwise
-          sudo snapcraft
+          sudo snapcraft --destructive
       - name: Output logs step
         if: always()
         run: |

--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -3,7 +3,7 @@ run-name: ${{ github.actor }} is creating testing snap
 on: [push]
 jobs:
   Create-Snap-Action:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - name: Check out repository code step

--- a/.github/workflows/create-snap-action.yml
+++ b/.github/workflows/create-snap-action.yml
@@ -6,25 +6,23 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - name: Check out repository code
+      - name: Check out repository code step
         uses: actions/checkout@v4
-      - name: Installation Step
+      - name: Installation step
         run: |
-          echo "Install snapcraft"
           sudo apt update
           sudo apt install snapcraft
-          echo "Install snapcraft"
           sudo snap install lxd
-          echo "Initialize snapcraft"
+          sudo snap install core24
           sudo lxd init --auto
-      - name: Run snapcraft
+      - name: Run snapcraft step
         run: | 
           cd tests
           # run snapcraft in destructive mode 
           # -- network doesn't work properly otherwise
           sudo snapcraft --destructive-mode
-      - name: Output logs
+      - name: Output logs step
         if: always()
         run: |
-          journalctl -u snap.multipass.multipassd
+          journalctl -u snap.lxd.daemon
           sudo bash -c 'cat /root/.local/state/snapcraft/log/snapcraft*.log'


### PR DESCRIPTION
Adding github action to create snap build on repo push using github hosted runner. Notes:

-  When using snapcraft, the created container, during snapcraft build, doesn't appear to get an IP address and, as a result, doesn't work properly without using "--destructive" option of snapcraft
- When using "--destructive" mode of snapcraft, we can't use 22.04 (jammy) since the snap is meant to be built with 24.04 (noble).  Therefore, we have to use "24.04" (noble) as the "runs-on" option for github action