### PR TITLE
trap on errors

### DIFF
--- a/guest-tools/image/setup.sh
+++ b/guest-tools/image/setup.sh
@@ -4,6 +4,20 @@
 #
 # This file is part of tdx repo. See LICENSE file for license information.
 
+_on_error() {
+  trap '' ERR
+  line_path=$(caller)
+  line=${line_path% *}
+  path=${line_path#* }
+
+  echo ""
+  echo "ERR $path:$line $BASH_COMMAND exited with $1"
+  exit 1
+}
+trap '_on_error $?' ERR
+
+set -eE
+
 apt update
 
 # Utilities packages for automated testing

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -16,6 +16,20 @@
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
 
+_on_error() {
+  trap '' ERR
+  line_path=$(caller)
+  line=${line_path% *}
+  path=${line_path#* }
+
+  echo ""
+  echo "ERR $path:$line $BASH_COMMAND exited with $1"
+  exit 1
+}
+trap '_on_error $?' ERR
+
+set -eE
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # source config file


### PR DESCRIPTION
Most of the shell scripts in this repo are missing `set -e` to stop on error.

For example, if `apt update` fails due to network error the script will just continue ( https://github.com/canonical/tdx/blob/8e2fced50bccd89275b3acf1b644dd915c4d7224/guest-tools/image/setup.sh#L7)

This PR adds not only that but also -E to stop inside of functions and does not just exit, but reports the error location nicely.

Next step would be to add this to all shell scripts.