### PR TITLE
Remove redundant -cpu option of qemu

### DIFF
--- a/guest-tools/regular_vm.xml.template
+++ b/guest-tools/regular_vm.xml.template
@@ -50,8 +50,6 @@
   </devices>
   <allowReboot value='no'/>
   <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
     <qemu:arg value='-device'/>
     <qemu:arg value='virtio-net-pci,netdev=nic0,bus=pcie.0,addr=0x5'/>
     <qemu:arg value='-netdev'/>

--- a/guest-tools/trust_domain-sb.xml.template
+++ b/guest-tools/trust_domain-sb.xml.template
@@ -57,8 +57,6 @@
     <policy>0x10000000</policy>
   </launchSecurity>
   <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
     <qemu:arg value='-device'/>
     <qemu:arg value='virtio-net-pci,netdev=nic0,bus=pcie.0,addr=0x5'/>
     <qemu:arg value='-netdev'/>

--- a/guest-tools/trust_domain.xml.template
+++ b/guest-tools/trust_domain.xml.template
@@ -57,8 +57,6 @@
     <policy>0x10000000</policy>
   </launchSecurity>
   <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
     <qemu:arg value='-device'/>
     <qemu:arg value='virtio-net-pci,netdev=nic0,bus=pcie.0,addr=0x5'/>
     <qemu:arg value='-netdev'/>


### PR DESCRIPTION
The domain definition already enforces usage of host-passthrough CPU mode, so adding -cpu host is redundant.