### PR TITLE
Dev fix quote generation configfs tsm

### DIFF
--- a/guest-tools/trust_domain-sb.xml.template
+++ b/guest-tools/trust_domain-sb.xml.template
@@ -55,6 +55,9 @@
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
     <policy>0x10000000</policy>
+    <quoteGenerationService>
+      <SocketAddress type='vsock' cid='2' port='4050'/>
+    </quoteGenerationService>
   </launchSecurity>
   <qemu:commandline>
     <qemu:arg value='-device'/>

--- a/guest-tools/trust_domain.xml.template
+++ b/guest-tools/trust_domain.xml.template
@@ -55,7 +55,9 @@
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
     <policy>0x10000000</policy>
-    <Quote-Generation-Service>vsock:2:4050</Quote-Generation-Service>
+    <quoteGenerationService>
+      <SocketAddress type='vsock' cid='2' port='4050'/>
+    </quoteGenerationService>
   </launchSecurity>
   <qemu:commandline>
     <qemu:arg value='-device'/>

--- a/guest-tools/trust_domain.xml.template
+++ b/guest-tools/trust_domain.xml.template
@@ -55,6 +55,7 @@
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
     <policy>0x10000000</policy>
+    <Quote-Generation-Service>vsock:2:4050</Quote-Generation-Service>
   </launchSecurity>
   <qemu:commandline>
     <qemu:arg value='-device'/>


### PR DESCRIPTION
Fixes  #178 

PEK-905

A fix on libvirt has been done to use the right qemu argument to specify the QGS communication channel
this fix will also rename the libvirt conf field name from `Quote-Generation-Service` to `quoteGenerationService`
This commit will update the libvirt configuration to use the new libvirt configuration option

It also updates  the `run_td.sh` script to add support for the qemu QGS option 