### PR TITLE
Add GitHub issues template and related system report script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**System report**
+Please run the [system-report.sh](../../system-report.sh) script on your
+host system and copy the output below.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an improvement or enhancement for the project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I always have to edit this manually to [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+**System report**
+If you think it would be helpful, please run the
+[system-report.sh](../../system-report.sh) script on your host system and copy the
+output below.

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,6 +1,6 @@
 ---
 name: Support Request
-about: Support request or question relating to Intel Device Plugins for Kubernetes
+about: Support request or question relating to TDX on Ubuntu
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -4,7 +4,7 @@ about: Support request or question relating to TDX on Ubuntu
 
 ---
 
-<!-- BEFORE SUBMISSION: Please read any known issues and workarounds in the plugin's readme. -->
+<!-- BEFORE SUBMISSION: Please review known issues prior to submitting a request. -->
 
 **Describe the support request**
 A clear and concise description of what you are looking support for.

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,14 @@
+---
+name: Support Request
+about: Support request or question relating to Intel Device Plugins for Kubernetes
+
+---
+
+<!-- BEFORE SUBMISSION: Please read any known issues and workarounds in the plugin's readme. -->
+
+**Describe the support request**
+A clear and concise description of what you are looking support for.
+
+**System report**
+Please run the [system-report.sh](../../system-report.sh) script on your
+host system and copy the output below.

--- a/system-report.sh
+++ b/system-report.sh
@@ -65,7 +65,7 @@ result=$(sudo dmesg | grep -i tdx)
 print_section "TDX kernel logs" "${result}"
 
 result=$( \
-if grep -q tdddx /proc/cpuinfo; then \
+if grep -q tdx /proc/cpuinfo; then \
   echo "CPU supports TDX according to /proc/cpuinfo"; \
 else echo "No TDX support in CPU according to /proc/cpuinfo"; \
 fi)

--- a/system-report.sh
+++ b/system-report.sh
@@ -57,12 +57,10 @@ set_msr_result_string() {
     result="$result\nSEAM_RR bit: $SEAM_RR (expected value: 1)"
     NUM_TDX_PRIV_KEYS=$(sudo rdmsr 0x87 -f 63:32)
     result="$result\nNUM_TDX_PRIV_KEYS: $NUM_TDX_PRIV_KEYS (expected value: >32)"
-    MSR_EXTRA1=$(sudo rdmsr 0xa0)
-    result="$result\nMSR_EXTRA1 (0xa0): $MSR_EXTRA1 (expected value: 0)"
-    MSR_EXTRA2=$(sudo rdmsr 0x1f5 -f 11:11)
-    result="$result\nMSR_EXTRA2 (0x1f5, bit 11): $MSR_EXTRA2 (expected value: 1)"
-    MSR_EXTRA3=$(sudo rdmsr 0x1401 -f 11:11)
-    result="$result\nMSR_EXTRA3 (0x1401, bit 11): $MSR_EXTRA3 (expected value: 1)"
+    SGX_AND_MCHECK_STATUS=$(sudo rdmsr 0xa0)
+    result="$result\nSGX_AND_MCHECK_STATUS: $SGX_AND_MCHECK_STATUS (expected value: 0)"
+    TDX_STATUS=$(sudo rdmsr 0x1401 -f 11:11)
+    result="$result\nTDX_STATUS bit: $TDX_STATUS (expected value: 1)"
 }
 
 printf "If you are running this for reporting an issue on GitHub,\n"

--- a/system-report.sh
+++ b/system-report.sh
@@ -57,6 +57,12 @@ set_msr_result_string() {
   result="$result\nSEAM_RR bit: $SEAM_RR (expected value: 1)"
   NUM_TDX_PRIV_KEYS=$(sudo rdmsr 0x87 -f 63:32)
   result="$result\nNUM_TDX_PRIV_KEYS: $NUM_TDX_PRIV_KEYS (expected value: >32)"
+  MSR_EXTRA1=$(sudo rdmsr 0xa0)
+  result="$result\nMSR_EXTRA1 (0xa0): $MSR_EXTRA1 (expected value: 0)"
+  MSR_EXTRA2=$(sudo rdmsr 0x1f5 -f 11:11)
+  result="$result\nMSR_EXTRA2 (0x1f5, bit 11): $MSR_EXTRA2 (expected value: 1)"
+  MSR_EXTRA3=$(sudo rdmsr 0x1401 -f 11:11)
+  result="$result\nMSR_EXTRA3 (0x1401, bit 11): $MSR_EXTRA3 (expected value: 1)"
 }
 
 printf "If you are running this for reporting an issue on GitHub,\n"
@@ -110,5 +116,14 @@ print_section "sgx-ra-service package details" "${result}"
 
 set_pkg_result_string "sgx-pck-id-retrieval-tool"
 print_section "sgx-pck-id-retrieval-tool package details" "${result}"
+
+result=$(systemctl status qgsd 2>&1)
+print_section "QGSD service status" "${result}"
+
+result=$(systemctl status pccs 2>&1)
+print_section "PCCS service status" "${result}"
+
+result=$(tail -n 30 /var/log/mpa_registration.log)
+print_section "MPA registration logs (last 30 lines)" "${result}"
 
 printf "<======== COPY ABOVE HERE ========>\n"

--- a/system-report.sh
+++ b/system-report.sh
@@ -59,8 +59,6 @@ set_msr_result_string() {
     result="$result\nNUM_TDX_PRIV_KEYS: $NUM_TDX_PRIV_KEYS (expected value: >32)"
     SGX_AND_MCHECK_STATUS=$(sudo rdmsr 0xa0)
     result="$result\nSGX_AND_MCHECK_STATUS: $SGX_AND_MCHECK_STATUS (expected value: 0)"
-    TDX_STATUS=$(sudo rdmsr 0x1401 -f 11:11)
-    result="$result\nTDX_STATUS bit: $TDX_STATUS (expected value: 1)"
 }
 
 printf "If you are running this for reporting an issue on GitHub,\n"

--- a/system-report.sh
+++ b/system-report.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# This file is part of Canonical's TDX repository which includes tools
+# to setup and configure a confidential computing environment
+# based on Intel TDX technology.
+# See the LICENSE file in the repository for the license text.
+
+# Copyright 2024 Canonical Ltd.
+# SPDX-License-Identifier: GPL-3.0-only
+
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranties
+# of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+
+#
+# This script outputs relevant system information for
+# reporting TDX issues at:
+#
+# https://github.com/canonical/tdx/issues
+#
+
+print_section() {
+  if [ $# -ne 2 ]; then
+    >&2 echo "$0 <header> <command output>"
+    exit 1
+  fi
+  header=$1
+  cmdout=$2
+  printf "### ${header}\n\n"
+  printf "\`\`\`\n"
+  printf "${cmdout}"
+  printf "\n\`\`\`\n\n"
+}
+
+set_pkg_result_string() {
+  if [ $# -ne 1 ]; then
+    >&2 echo "$0 <package>"
+    exit 1
+  fi
+  package=$1
+  result=$( \
+  if dpkg -s ${package} &> /dev/null; then \
+    echo "Status: Installed"; \
+  else echo "Status: Not Installed"; \
+  fi)
+  result="$result\n$(apt info ${package} 2>/dev/null | grep -E 'Package|Version|APT-Sources')"
+}
+
+printf "If you are running this for reporting an issue on GitHub,\n"
+printf "copy all output between the markers below.\n\n"
+
+printf "<======== COPY BELOW HERE ========>\n\n"
+
+result=$(lsb_release -a)
+print_section "Operating system details" "${result}"
+
+result=$(uname -rvpio) # show everything but hostname
+print_section "Kernel version" "${result}"
+
+result=$(sudo dmesg | grep -i tdx)
+print_section "TDX kernel logs" "${result}"
+
+result=$( \
+if grep -q tdddx /proc/cpuinfo; then \
+  echo "CPU supports TDX according to /proc/cpuinfo"; \
+else echo "No TDX support in CPU according to /proc/cpuinfo"; \
+fi)
+print_section "TDX CPU instruction support" "${result}"
+
+result=$(grep -m1 "model name" /proc/cpuinfo | cut -f2 -d":")
+print_section "CPU details" "${result}"
+
+result=$(find . -name check-production.sh -exec \
+  sh -c 'cd "$(dirname "$0")" && sudo ./check-production.sh' {} \;)
+print_section "Production system check" "${result}"
+
+set_pkg_result_string "qemu-system-x86"
+print_section "QEMU package details" "${result}"
+
+set_pkg_result_string "libvirt-clients"
+print_section "Libvirt package details" "${result}"
+
+set_pkg_result_string "ovmf"
+print_section "OVMF package details" "${result}"
+
+set_pkg_result_string "sgx-dcap-pccs"
+print_section "sgx-dcap-pccs package details" "${result}"
+
+set_pkg_result_string "tdx-qgs"
+print_section "tdx-qgs package details" "${result}"
+
+set_pkg_result_string "sgx-ra-service"
+print_section "sgx-ra-service package details" "${result}"
+
+set_pkg_result_string "sgx-pck-id-retrieval-tool"
+print_section "sgx-pck-id-retrieval-tool package details" "${result}"
+
+printf "<======== COPY ABOVE HERE ========>\n"

--- a/system-report.sh
+++ b/system-report.sh
@@ -24,45 +24,45 @@
 #
 
 print_section() {
-  if [ $# -ne 2 ]; then
-    >&2 echo "$0 <header> <command output>"
-    exit 1
-  fi
-  header=$1
-  cmdout=$2
-  printf "### ${header}\n\n"
-  printf "\`\`\`\n"
-  printf "${cmdout}"
-  printf "\n\`\`\`\n\n"
+    if [ $# -ne 2 ]; then
+        >&2 echo "$0 <header> <command output>"
+        exit 1
+    fi
+    header=$1
+    cmdout=$2
+    printf "### ${header}\n\n"
+    printf "\`\`\`\n"
+    printf "${cmdout}"
+    printf "\n\`\`\`\n\n"
 }
 
 set_pkg_result_string() {
-  if [ $# -ne 1 ]; then
-    >&2 echo "$0 <package>"
-    exit 1
-  fi
-  package=$1
-  result=$( \
-  if dpkg -s ${package} &> /dev/null; then \
-    echo "Status: Installed"; \
-  else echo "Status: Not Installed"; \
-  fi)
-  result="$result\n$(apt info ${package} 2>/dev/null | grep -E 'Package|Version|APT-Sources')"
+    if [ $# -ne 1 ]; then
+        >&2 echo "$0 <package>"
+        exit 1
+    fi
+    package=$1
+    result=$( \
+    if dpkg -s ${package} &> /dev/null; then \
+        echo "Status: Installed"; \
+    else echo "Status: Not Installed"; \
+    fi)
+    result="$result\n$(apt info ${package} 2>/dev/null | grep -E 'Package|Version|APT-Sources')"
 }
 
 set_msr_result_string() {
-  HW_ENCRYPT_ENABLE=$(sudo rdmsr 0x982 -f 1:1)
-  result="HW_ENCRYPT_ENABLE bit: ${HW_ENCRYPT_ENABLE} (expected value: 1)"
-  SEAM_RR=$(sudo rdmsr 0x1401 -f 11:11)
-  result="$result\nSEAM_RR bit: $SEAM_RR (expected value: 1)"
-  NUM_TDX_PRIV_KEYS=$(sudo rdmsr 0x87 -f 63:32)
-  result="$result\nNUM_TDX_PRIV_KEYS: $NUM_TDX_PRIV_KEYS (expected value: >32)"
-  MSR_EXTRA1=$(sudo rdmsr 0xa0)
-  result="$result\nMSR_EXTRA1 (0xa0): $MSR_EXTRA1 (expected value: 0)"
-  MSR_EXTRA2=$(sudo rdmsr 0x1f5 -f 11:11)
-  result="$result\nMSR_EXTRA2 (0x1f5, bit 11): $MSR_EXTRA2 (expected value: 1)"
-  MSR_EXTRA3=$(sudo rdmsr 0x1401 -f 11:11)
-  result="$result\nMSR_EXTRA3 (0x1401, bit 11): $MSR_EXTRA3 (expected value: 1)"
+    HW_ENCRYPT_ENABLE=$(sudo rdmsr 0x982 -f 1:1)
+    result="HW_ENCRYPT_ENABLE bit: ${HW_ENCRYPT_ENABLE} (expected value: 1)"
+    SEAM_RR=$(sudo rdmsr 0x1401 -f 11:11)
+    result="$result\nSEAM_RR bit: $SEAM_RR (expected value: 1)"
+    NUM_TDX_PRIV_KEYS=$(sudo rdmsr 0x87 -f 63:32)
+    result="$result\nNUM_TDX_PRIV_KEYS: $NUM_TDX_PRIV_KEYS (expected value: >32)"
+    MSR_EXTRA1=$(sudo rdmsr 0xa0)
+    result="$result\nMSR_EXTRA1 (0xa0): $MSR_EXTRA1 (expected value: 0)"
+    MSR_EXTRA2=$(sudo rdmsr 0x1f5 -f 11:11)
+    result="$result\nMSR_EXTRA2 (0x1f5, bit 11): $MSR_EXTRA2 (expected value: 1)"
+    MSR_EXTRA3=$(sudo rdmsr 0x1401 -f 11:11)
+    result="$result\nMSR_EXTRA3 (0x1401, bit 11): $MSR_EXTRA3 (expected value: 1)"
 }
 
 printf "If you are running this for reporting an issue on GitHub,\n"
@@ -81,7 +81,7 @@ print_section "TDX kernel logs" "${result}"
 
 result=$( \
 if grep -q tdx /proc/cpuinfo; then \
-  echo "CPU supports TDX according to /proc/cpuinfo"; \
+    echo "CPU supports TDX according to /proc/cpuinfo"; \
 else echo "No TDX support in CPU according to /proc/cpuinfo"; \
 fi)
 print_section "TDX CPU instruction support" "${result}"
@@ -93,7 +93,7 @@ result=$(grep -m1 "model name" /proc/cpuinfo | cut -f2 -d":")
 print_section "CPU details" "${result}"
 
 result=$(find . -name check-production.sh -exec \
-  sh -c 'cd "$(dirname "$0")" && sudo ./check-production.sh' {} \;)
+    sh -c 'cd "$(dirname "$0")" && sudo ./check-production.sh' {} \;)
 print_section "Production system check" "${result}"
 
 set_pkg_result_string "qemu-system-x86"

--- a/system-report.sh
+++ b/system-report.sh
@@ -50,6 +50,15 @@ set_pkg_result_string() {
   result="$result\n$(apt info ${package} 2>/dev/null | grep -E 'Package|Version|APT-Sources')"
 }
 
+set_msr_result_string() {
+  HW_ENCRYPT_ENABLE=$(sudo rdmsr 0x982 -f 1:1)
+  result="HW_ENCRYPT_ENABLE bit: ${HW_ENCRYPT_ENABLE} (expected value: 1)"
+  SEAM_RR=$(sudo rdmsr 0x1401 -f 11:11)
+  result="$result\nSEAM_RR bit: $SEAM_RR (expected value: 1)"
+  NUM_TDX_PRIV_KEYS=$(sudo rdmsr 0x87 -f 63:32)
+  result="$result\nNUM_TDX_PRIV_KEYS: $NUM_TDX_PRIV_KEYS (expected value: >32)"
+}
+
 printf "If you are running this for reporting an issue on GitHub,\n"
 printf "copy all output between the markers below.\n\n"
 
@@ -70,6 +79,9 @@ if grep -q tdx /proc/cpuinfo; then \
 else echo "No TDX support in CPU according to /proc/cpuinfo"; \
 fi)
 print_section "TDX CPU instruction support" "${result}"
+
+set_msr_result_string
+print_section "Model specific registers (MSRs)" "${result}"
 
 result=$(grep -m1 "model name" /proc/cpuinfo | cut -f2 -d":")
 print_section "CPU details" "${result}"


### PR DESCRIPTION
This adds issues template and a system reporting script to help us to better support users of this repo and triage issues.

There may be other system details that would be helpful here. For example, is it possible to get the tdx module version from the CLI (I briefly searched around but did not come across anything)? Or are there other packages that should be included?

For reference, I'm pasting the results of running the system report script from a production system below. Some notes about the output:

* I personally think it's most convenient (both for users and maintainers) to have the report directly in the body of the issue rather than uploading a file. 
* I also considered a bulleted list rather than entire sections but I found the section-based approach easier to read/parse.

 
### Operating system details

```
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04 LTS
Release:	24.04
Codename:	noble
```

### Kernel version

```
6.8.0-1009-intel #16-Ubuntu SMP PREEMPT_DYNAMIC Thu Jul 18 15:46:59 UTC 2024 x86_64 x86_64 GNU/Linux
```

### TDX kernel logs

```
[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-6.8.0-1009-intel root=UUID=2def89e0-5f60-4b15-9fc3-40df79380b94 ro kvm_intel.tdx=1 nohibernate
[    0.651972] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-6.8.0-1009-intel root=UUID=2def89e0-5f60-4b15-9fc3-40df79380b94 ro kvm_intel.tdx=1 nohibernate
[    1.378492] virt/tdx: BIOS enabled: private KeyID range [64, 128)
[    1.378496] virt/tdx: Disable ACPI S3. Turn off TDX in the BIOS to use ACPI S3.
[    8.317823] virt/tdx: TDX module: attributes 0x0, vendor_id 0x8086, major_version 1, minor_version 5, build_date 20240129, build_num 698
[    8.317827] virt/tdx: CMR: [0x100000, 0x77800000)
[    8.317828] virt/tdx: CMR: [0x100000000, 0x206e000000)
[    8.317828] virt/tdx: CMR: [0x2080000000, 0x4070000000)
[    9.015808] virt/tdx: 1050636 KB allocated for PAMT
[    9.015813] virt/tdx: module initialized
```

### TDX CPU instruction support

```
CPU supports TDX according to /proc/cpuinfo
```

### CPU details

```
 Intel(R) Xeon(R) Platinum 8488C
```

### Production system check

```
CPU: Sapphire Rapids
Production
```

### QEMU package details

```
Status: Installed
Package: qemu-system-x86
Version: 1:8.2.2+ds-0ubuntu2+tdx1.0~tdx1.202407191424~ubuntu24.04.1
APT-Sources: https://ppa.launchpadcontent.net/kobuk-team/tdx/ubuntu noble/main amd64 Packages
```

### Libvirt package details

```
Status: Installed
Package: libvirt-clients
Version: 10.0.0-2ubuntu8.3-tdx1.1+tdx.202407260818~ubuntu24.04.1
APT-Sources: https://ppa.launchpadcontent.net/kobuk-team/tdx/ubuntu noble/main amd64 Packages
```

### OVMF package details

```
Status: Installed
Package: ovmf
Version: 2024.02-2+ppa2+tdx.202407031341~ubuntu24.04.1
APT-Sources: https://ppa.launchpadcontent.net/kobuk-team/tdx/ubuntu noble/main amd64 Packages
```

### sgx-dcap-pccs package details

```
Status: Installed
Package: sgx-dcap-pccs
Version: 1.21-1~202407240841~ubuntu24.04.1
APT-Sources: https://ppa.launchpadcontent.net/kobuk-team/tdx/ubuntu noble/main amd64 Packages
```

### tdx-qgs package details

```
Status: Installed
Package: tdx-qgs
Version: 1.21-1~202407220704~ubuntu24.04.1
APT-Sources: https://ppa.launchpadcontent.net/kobuk-team/tdx/ubuntu noble/main amd64 Packages
```

### sgx-ra-service package details

```
Status: Installed
Package: sgx-ra-service
Version: 1.21-1~202407220704~ubuntu24.04.1
APT-Sources: https://ppa.launchpadcontent.net/kobuk-team/tdx/ubuntu noble/main amd64 Packages
Description: Intel(R) Software Guard Extensions Multi-Package Registration Agent Service
```

### sgx-pck-id-retrieval-tool package details

```
Status: Installed
Package: sgx-pck-id-retrieval-tool
Version: 1.21-1~202407220704~ubuntu24.04.1
APT-Sources: https://ppa.launchpadcontent.net/kobuk-team/tdx/ubuntu noble/main amd64 Packages
```

