### PR TITLE
system-report.sh : various fixes

### DIFF
--- a/system-report.sh
+++ b/system-report.sh
@@ -106,10 +106,6 @@ print_section "Model specific registers (MSRs)" "${result}"
 result=$(grep -m1 "model name" /proc/cpuinfo | cut -f2 -d":")
 print_section "CPU details" "${result}"
 
-result=$(find . -name check-production.sh -exec \
-    sh -c 'cd "$(dirname "$0")" && sudo ./check-production.sh' {} \;)
-print_section "Production system check" "${result}"
-
 set_pkg_result_string "qemu-system-x86"
 print_section "QEMU package details" "${result}"
 

--- a/system-report.sh
+++ b/system-report.sh
@@ -60,8 +60,8 @@ install_msr() {
 
 set_msr_result_string() {
     install_msr
-    MK_TME_ENABLE=$(sudo rdmsr 0x982 -f 1:1)
-    result="MK_TME_ENABLE bit: ${MK_TME_ENABLE} (expected value: 1)"
+    MK_TME_ENABLED=$(sudo rdmsr 0x982 -f 1:1)
+    result="MK_TME_ENABLED bit: ${MK_TME_ENABLE} (expected value: 1)"
     SEAM_RR=$(sudo rdmsr 0x1401 -f 11:11)
     result="$result\nSEAM_RR bit: $SEAM_RR (expected value: 1)"
     NUM_TDX_PRIV_KEYS=$(sudo rdmsr 0x87 -f 63:32)


### PR DESCRIPTION
- Install msr-tools and load msr driver if not present this is required to read MSR values
- MSR value : rename HW_ENCRYPT_ENABLE to MK_TME_ENABLE
- Add check production to MSR section
- Nicely handle the case where mpa_registration.log is not available

Fixes #192