### PR TITLE
Allow password authentication method for ssh

### DIFF
--- a/guest-tools/image/setup.sh
+++ b/guest-tools/image/setup.sh
@@ -29,6 +29,9 @@ apt install -y cpuid linux-tools-common msr-tools
 sed -i 's|[#]*PasswordAuthentication .*|PasswordAuthentication yes|g' /etc/ssh/sshd_config
 sed -i 's|[#]*PermitRootLogin .*|PermitRootLogin yes|g' /etc/ssh/sshd_config
 sed -i 's|[#]*KbdInteractiveAuthentication .*|KbdInteractiveAuthentication yes|g' /etc/ssh/sshd_config
+# livecd-rootfs adds 60-cloudimg-settings.conf file to set PasswordAuthentication to no
+# if the file exists, remove it
+rm -f /etc/ssh/sshd_config.d/60-cloudimg-settings.conf
 
 # Enable TDX
 /tmp/tdx/setup-tdx-guest.sh


### PR DESCRIPTION
livecd-rootfs disables the password auth method for sshd by adding sshd config snippet 60-cloudimg-settings.conf the passord auth method is still possible with the keyboard-interactive method but when a client specifies password as the only authorized method by issuing: ssh -o PreferredAuthentications=password ... the auth fails.

Fixes #209