### PR TITLE
tests: tell tox to capture the TDXTEST_DEBUG variable

### DIFF
--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = True
 
 [testenv]
 allowlist_externals=bash
-pass_env = TDXTEST_GUEST_IMG
+pass_env = TDXTEST_GUEST_IMG, TDXTEST_DEBUG
 envdir = {toxworkdir}/.venv
 deps =
   paramiko==3.3.1


### PR DESCRIPTION
This variable is to specify the tests to not clean up the guest VMs This is useful for debugging purposes