### PR TITLE
Improve the management of workdir cleanup for debugging purposes

### DIFF
--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+
+import Qemu
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests(tmpdir):
+    """
+    Fixture to execute before and after a test is run
+    Even in case of test failure
+    """
+    # Setup: fill with any logic you want
+    # enable the debug flag if TDXTEST_DEBUG is set
+    debug = os.environ.get('TDXTEST_DEBUG', False)
+    if debug:
+        Qemu.QemuMachine.set_debug(debug)
+
+    yield # this is where the testing happens
+
+    # Teardown : fill with any logic you want
+
+def pytest_exception_interact(node, call, report):
+    """
+    Called at test failure
+    """
+    if report.failed:
+        # enable debug flag to avoid cleanup to happen
+        Qemu.QemuMachine.set_debug(True)


### PR DESCRIPTION
- In case of test failure, we would like that the workdir of qemu is not cleaned up so that we can do some debugging.
- Improve the management of environment variable TDXTEST_DEBUG that forbids the clean up of these workdirs at any case