### PR TITLE
Use GiB as unit for memory conf in libvirt configuration

### DIFF
--- a/guest-tools/regular_vm.xml.template
+++ b/guest-tools/regular_vm.xml.template
@@ -1,6 +1,6 @@
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>DOMAIN</name>
-  <memory unit='KiB'>2097152</memory>
+  <memory unit='GiB'>2</memory>
   <vcpu placement="static">16</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>

--- a/guest-tools/trust_domain-sb.xml.template
+++ b/guest-tools/trust_domain-sb.xml.template
@@ -1,6 +1,6 @@
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>DOMAIN</name>
-  <memory unit='KiB'>2097152</memory>
+  <memory unit='GiB'>2</memory>
   <memoryBacking>
     <source type="anonymous"/>
     <access mode="private"/>

--- a/guest-tools/trust_domain.xml.template
+++ b/guest-tools/trust_domain.xml.template
@@ -1,6 +1,6 @@
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>DOMAIN</name>
-  <memory unit='KiB'>2097152</memory>
+  <memory unit='GiB'>2</memory>
   <memoryBacking>
     <source type="anonymous"/>
     <access mode="private"/>


### PR DESCRIPTION
It is easier to work with Gb unit, this change is to ease the users when they want to quickly configure the VM memory to an other value for testing