### PR TITLE
improve tox setup script and config

### DIFF
--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = True
 [testenv]
 allowlist_externals =
   bash
-  {toxinidir}/tests/setup-env-tox.sh
+  {toxinidir}/tox/setup-env-tox.sh
 pass_env = TDXTEST_GUEST_IMG, TDXTEST_DEBUG
 envdir = {toxworkdir}/.venv
 deps =
@@ -20,7 +20,7 @@ setenv =
   PYTHONPATH={env:PYTHONPATH}:{toxinidir}/lib
 commands_pre =
   bash -c 'if [ `id -u` -ne 0 ]; then echo "Must run all tests with sudo" 1>&2; (exit -1); fi'
-  {toxinidir}/tests/setup-env-tox.sh
+  {toxinidir}/tox/setup-env-tox.sh
 
 [testenv:test_guest]
 commands = 

--- a/tests/tox/setup-env-tox.sh
+++ b/tests/tox/setup-env-tox.sh
@@ -36,22 +36,12 @@ cleanup() {
 }
 
 install_deps() {
-  sudo apt install -y python3-parameterized \
-         sshpass \
-         cpuid \
-         python3-cpuinfo
-  # Make sure kvm_intel is installed properly
-  # (one of the tests installed it with NOEPT)
-  sudo rmmod kvm_intel || true
-  sudo modprobe kvm_intel
+  sudo apt install -y sshpass
   sudo apt remove iperf3 -y
   sudo add-apt-repository ppa:kobuk-team/testing -y
-  sudo apt update
+  sudo apt update || true
   sudo apt install iperf-vsock -y
 }
-
-rm -rf /var/tmp/tdxtest
-mkdir -p /var/tmp/tdxtest
 
 if [ -z "${TDXTEST_GUEST_IMG}" ]; then
   if ! test -f $LOCAL_IMG; then


### PR DESCRIPTION
- simplify and improve tox setup script
remove useless python package installation because they are already installed in the tox venv

- move tox setup script in tox folder
this prevents the deployment of this script into the checkbox provider that does not use this script