### PR TITLE
fix kvm_intel module reload issue

### DIFF
--- a/tests/lib/Qemu.py
+++ b/tests/lib/Qemu.py
@@ -568,6 +568,8 @@ class QemuMachine:
         """
         Stop qemu process
         """
+        if self.proc is None:
+            return
         # self.proc.returncode== None -> not yet terminated
         if self.proc.returncode is None:
             try:

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -33,3 +33,11 @@ def release_kvm_use():
     Clean all running instances of qemu to release the kvm_intel driver use
     """
     Qemu.QemuMachine.stop_all_running_qemus()
+
+@pytest.fixture()
+def qm():
+    """
+    Fixture to create a QEMU machine as context manager
+    """
+    with Qemu.QemuMachine() as qm:
+        yield qm

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -26,3 +26,10 @@ def pytest_exception_interact(node, call, report):
     if report.failed:
         # enable debug flag to avoid cleanup to happen
         Qemu.QemuMachine.set_debug(True)
+
+@pytest.fixture()
+def release_kvm_use():
+    """
+    Clean all running instances of qemu to release the kvm_intel driver use
+    """
+    Qemu.QemuMachine.stop_all_running_qemus()

--- a/tests/tests/test_boot_basic.py
+++ b/tests/tests/test_boot_basic.py
@@ -19,30 +19,28 @@ import os
 import Qemu
 from common import *
 
-def test_guest_boot():
+def test_guest_boot(qm):
     """
     Boot TD
     """
-    with Qemu.QemuMachine() as qm:
-        qm.run()
+    qm.run()
 
-        m = Qemu.QemuSSH(qm)
+    m = Qemu.QemuSSH(qm)
 
-        deploy_and_setup(m)
+    deploy_and_setup(m)
 
-        # tdx guest device driver
-        m.check_exec('ls -la /dev/tdx_guest')
-        # CCEL table (event log)
-        m.check_exec('ls -la /sys/firmware/acpi/tables/CCEL')
+    # tdx guest device driver
+    m.check_exec('ls -la /dev/tdx_guest')
+    # CCEL table (event log)
+    m.check_exec('ls -la /sys/firmware/acpi/tables/CCEL')
 
-        qm.stop()
+    qm.stop()
 
-def test_early_printk():
+def test_guest_early_printk(qm):
     """
     Test Early Printk with Debug Off (Intel Case ID 018)
     """
 
-    qm = Qemu.QemuMachine()
     qm.qcmd.plugins['boot'].kernel = "/boot/vmlinuz"
     qm.qcmd.plugins['boot'].append = "earlyprintk=ttyS0,115200"
     qm.run()

--- a/tests/tests/test_boot_basic.py
+++ b/tests/tests/test_boot_basic.py
@@ -23,19 +23,19 @@ def test_guest_boot():
     """
     Boot TD
     """
-    qm = Qemu.QemuMachine()
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        qm.run()
 
-    m = Qemu.QemuSSH(qm)
+        m = Qemu.QemuSSH(qm)
 
-    deploy_and_setup(m)
+        deploy_and_setup(m)
 
-    # tdx guest device driver
-    m.check_exec('ls -la /dev/tdx_guest')
-    # CCEL table (event log)
-    m.check_exec('ls -la /sys/firmware/acpi/tables/CCEL')
+        # tdx guest device driver
+        m.check_exec('ls -la /dev/tdx_guest')
+        # CCEL table (event log)
+        m.check_exec('ls -la /sys/firmware/acpi/tables/CCEL')
 
-    qm.stop()
+        qm.stop()
 
 def test_early_printk():
     """

--- a/tests/tests/test_boot_coexist.py
+++ b/tests/tests/test_boot_coexist.py
@@ -29,16 +29,17 @@ def test_coexist_boot():
     qm = Qemu.QemuMachine('td',
                                QemuEfiMachine.OVMF_Q35_TDX,
                                service_blacklist = [QemuMachineService.QEMU_MACHINE_PORT_FWD])
-    qm.run()
     qm_normal = Qemu.QemuMachine('normal',
                                       QemuEfiMachine.OVMF_Q35,
                                       service_blacklist = [QemuMachineService.QEMU_MACHINE_PORT_FWD])
-    qm_normal.run()
+    with qm, qm_normal:
+        qm.run()
+        qm_normal.run()
 
-    m = Qemu.QemuMonitor(qm)
-    m.wait_for_state('running')
-    m_normal = Qemu.QemuMonitor(qm_normal)
-    m_normal.wait_for_state('running')
+        m = Qemu.QemuMonitor(qm)
+        m.wait_for_state('running')
+        m_normal = Qemu.QemuMonitor(qm_normal)
+        m_normal.wait_for_state('running')
 
-    qm.stop()
-    qm_normal.stop()
+        qm.stop()
+        qm_normal.stop()

--- a/tests/tests/test_boot_multiple.py
+++ b/tests/tests/test_boot_multiple.py
@@ -20,12 +20,11 @@
 import os
 import Qemu
 
-def test_4vcpus_1socket_10times():
+def test_4vcpus_1socket_10times(qm):
     """
     Test 4vcpus 1socket 10 times (Intel Case ID 009)
     """
 
-    qm = Qemu.QemuMachine()
     qm.qcmd.plugins['cpu'].nb_cores = 4
 
     for i in range(0,10):
@@ -34,12 +33,11 @@ def test_4vcpus_1socket_10times():
         qm.stop()
 
 
-def test_4vcpus_2sockets_5times():
+def test_4vcpus_2sockets_5times(qm):
     """
     Test 4vcpus 2sockets 5 times (Intel Case ID 010)
     """
 
-    qm = Qemu.QemuMachine()
     qm.qcmd.plugins['cpu'].nb_cores = 4
     qm.qcmd.plugins['cpu'].nb_sockets = 2
 

--- a/tests/tests/test_boot_td_creation.py
+++ b/tests/tests/test_boot_td_creation.py
@@ -20,20 +20,19 @@ import os
 from Qemu import QemuEfiMachine, QemuEfiFlashSize, QemuMachineService
 import Qemu
 
-def test_create_td_without_ovmf():
+def test_create_td_without_ovmf(qm):
     """
     TD creation should be impossible without OVMF
     qemu-system-x86_64 should output the errors:
       Cannot find TDX_METADATA_OFFSET_GUID
       failed to parse TDVF for TDX VM
     """
-    with Qemu.QemuMachine() as qm:
-        # remove ovmf
-        qm.qcmd.plugins.pop('ovmf')
-        qm.run()
+    # remove ovmf
+    qm.qcmd.plugins.pop('ovmf')
+    qm.run()
 
-        # expect qemu quit immediately 
-        _, err = qm.communicate()
-        assert "failed to parse TDVF for TDX VM" in err.decode()
+    # expect qemu quit immediately 
+    _, err = qm.communicate()
+    assert "failed to parse TDVF for TDX VM" in err.decode()
 
-        qm.stop()
+    qm.stop()

--- a/tests/tests/test_boot_td_creation.py
+++ b/tests/tests/test_boot_td_creation.py
@@ -27,13 +27,13 @@ def test_create_td_without_ovmf():
       Cannot find TDX_METADATA_OFFSET_GUID
       failed to parse TDVF for TDX VM
     """
-    qm = Qemu.QemuMachine()
-    # remove ovmf
-    qm.qcmd.plugins.pop('ovmf')
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        # remove ovmf
+        qm.qcmd.plugins.pop('ovmf')
+        qm.run()
 
-    # expect qemu quit immediately 
-    _, err = qm.communicate()
-    assert "failed to parse TDVF for TDX VM" in err.decode()
+        # expect qemu quit immediately 
+        _, err = qm.communicate()
+        assert "failed to parse TDVF for TDX VM" in err.decode()
 
-    qm.stop()
+        qm.stop()

--- a/tests/tests/test_guest_cpu_off.py
+++ b/tests/tests/test_guest_cpu_off.py
@@ -35,26 +35,26 @@ def test_guest_cpu_off():
     """
 
     # Startup Qemu and connect via SSH
-    qm = Qemu.QemuMachine()
-    qm.run()
-    m = Qemu.QemuSSH(qm)
+    with Qemu.QemuMachine() as qm:
+        qm.run()
+        m = Qemu.QemuSSH(qm)
 
-    # turn off arbitrary cpus
-    cpu = cpu_off_random()
+        # turn off arbitrary cpus
+        cpu = cpu_off_random()
     
-    # make sure the VM still does things
-    still_working = True
-    try:
-        m.check_exec('ls /tmp')
-    except Exception as e:
-        still_working = False
+        # make sure the VM still does things
+        still_working = True
+        try:
+            m.check_exec('ls /tmp')
+        except Exception as e:
+            still_working = False
 
-    qm.stop()
+        qm.stop()
 
-    # turn back on cpus
-    cpu_on_off(f'/sys/devices/system/cpu/cpu{cpu}/online', 1)
+        # turn back on cpus
+        cpu_on_off(f'/sys/devices/system/cpu/cpu{cpu}/online', 1)
 
-    assert still_working, 'VM dysfunction when a cpu is brought offline'
+        assert still_working, 'VM dysfunction when a cpu is brought offline'
 
 def test_guest_cpu_pinned_off():
     """
@@ -65,19 +65,19 @@ def test_guest_cpu_pinned_off():
     # the pinned cpu and making sure host still works
     for i in range(1,20):
         print(f'Iteration: {i}')
-        qm = Qemu.QemuMachine()
-        qm.run_and_wait()
+        with Qemu.QemuMachine() as qm:
+            qm.run_and_wait()
 
-        cpu = pin_process_on_random_cpu(qm.pid)
+            cpu = pin_process_on_random_cpu(qm.pid)
 
-        cpu_on_off(f'/sys/devices/system/cpu/cpu{cpu}/online', 0)
+            cpu_on_off(f'/sys/devices/system/cpu/cpu{cpu}/online', 0)
 
-        m = Qemu.QemuSSH(qm)
-        m.check_exec('sudo init 0 &')
+            m = Qemu.QemuSSH(qm)
+            m.check_exec('sudo init 0 &')
 
-        qm.stop()
+            qm.stop()
 
-        cpu_on_off(f'/sys/devices/system/cpu/cpu{cpu}/online', 1)
+            cpu_on_off(f'/sys/devices/system/cpu/cpu{cpu}/online', 1)
 
 def pin_process_on_random_cpu(pid):
     # pin pid to a particular cpu

--- a/tests/tests/test_guest_cpu_off.py
+++ b/tests/tests/test_guest_cpu_off.py
@@ -29,32 +29,31 @@ import util
 
 script_path=os.path.dirname(os.path.realpath(__file__))
 
-def test_guest_cpu_off():
+def test_guest_cpu_off(qm):
     """
     tdx_VMP_cpu_onoff test case (See https://github.com/intel/tdx/wiki/Tests)
     """
 
     # Startup Qemu and connect via SSH
-    with Qemu.QemuMachine() as qm:
-        qm.run()
-        m = Qemu.QemuSSH(qm)
+    qm.run()
+    m = Qemu.QemuSSH(qm)
 
-        # turn off arbitrary cpus
-        cpu = cpu_off_random()
+    # turn off arbitrary cpus
+    cpu = cpu_off_random()
     
-        # make sure the VM still does things
-        still_working = True
-        try:
-            m.check_exec('ls /tmp')
-        except Exception as e:
-            still_working = False
+    # make sure the VM still does things
+    still_working = True
+    try:
+        m.check_exec('ls /tmp')
+    except Exception as e:
+        still_working = False
 
-        qm.stop()
+    qm.stop()
 
-        # turn back on cpus
-        cpu_on_off(f'/sys/devices/system/cpu/cpu{cpu}/online', 1)
+    # turn back on cpus
+    cpu_on_off(f'/sys/devices/system/cpu/cpu{cpu}/online', 1)
 
-        assert still_working, 'VM dysfunction when a cpu is brought offline'
+    assert still_working, 'VM dysfunction when a cpu is brought offline'
 
 def test_guest_cpu_pinned_off():
     """

--- a/tests/tests/test_guest_eventlog.py
+++ b/tests/tests/test_guest_eventlog.py
@@ -24,36 +24,34 @@ import Qemu
 import util
 from common import *
 
-def test_guest_eventlog():
+def test_guest_eventlog(qm):
     """
     Dump event log
     """
-    with Qemu.QemuMachine() as qm:
-        qm.run()
+    qm.run()
 
-        m = Qemu.QemuSSH(qm)
+    m = Qemu.QemuSSH(qm)
 
-        deploy_and_setup(m)
+    deploy_and_setup(m)
 
-        stdout, stderr = m.check_exec('tdeventlog')
-        for l in stderr.readlines():
-            print(l.rstrip())
+    stdout, stderr = m.check_exec('tdeventlog')
+    for l in stderr.readlines():
+        print(l.rstrip())
 
-        qm.stop()
+    qm.stop()
 
-def test_guest_eventlog_initrd():
+def test_guest_eventlog_initrd(qm):
     """
     Check presence of event log for initrd measurement
     """
-    with Qemu.QemuMachine() as qm:
-        qm.run()
+    qm.run()
 
-        m = Qemu.QemuSSH(qm)
+    m = Qemu.QemuSSH(qm)
 
-        deploy_and_setup(m)
+    deploy_and_setup(m)
 
-        stdout, stderr = m.check_exec('tdeventlog_check_initrd')
-        for l in stderr.readlines():
-            print(l.rstrip())
+    stdout, stderr = m.check_exec('tdeventlog_check_initrd')
+    for l in stderr.readlines():
+        print(l.rstrip())
 
-        qm.stop()
+    qm.stop()

--- a/tests/tests/test_guest_eventlog.py
+++ b/tests/tests/test_guest_eventlog.py
@@ -28,32 +28,32 @@ def test_guest_eventlog():
     """
     Dump event log
     """
-    qm = Qemu.QemuMachine()
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        qm.run()
 
-    m = Qemu.QemuSSH(qm)
+        m = Qemu.QemuSSH(qm)
 
-    deploy_and_setup(m)
+        deploy_and_setup(m)
 
-    stdout, stderr = m.check_exec('tdeventlog')
-    for l in stderr.readlines():
-        print(l.rstrip())
+        stdout, stderr = m.check_exec('tdeventlog')
+        for l in stderr.readlines():
+            print(l.rstrip())
 
-    qm.stop()
+        qm.stop()
 
 def test_guest_eventlog_initrd():
     """
     Check presence of event log for initrd measurement
     """
-    qm = Qemu.QemuMachine()
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        qm.run()
 
-    m = Qemu.QemuSSH(qm)
+        m = Qemu.QemuSSH(qm)
 
-    deploy_and_setup(m)
+        deploy_and_setup(m)
 
-    stdout, stderr = m.check_exec('tdeventlog_check_initrd')
-    for l in stderr.readlines():
-        print(l.rstrip())
+        stdout, stderr = m.check_exec('tdeventlog_check_initrd')
+        for l in stderr.readlines():
+            print(l.rstrip())
 
-    qm.stop()
+        qm.stop()

--- a/tests/tests/test_guest_fail.py
+++ b/tests/tests/test_guest_fail.py
@@ -27,7 +27,7 @@ import util
 
 script_path=os.path.dirname(os.path.realpath(__file__))
 
-def test_guest_noept_fail(release_kvm_use):
+def test_guest_noept_fail(qm, release_kvm_use):
     """
     tdx_NOEPT test case (See https://github.com/intel/tdx/wiki/Tests)
     """
@@ -49,26 +49,24 @@ def test_guest_noept_fail(release_kvm_use):
         assert dmesg_end_count == dmesg_start_count+1, "dmesg missing proper message"
 
         # Run Qemu and verify failure
-        with Qemu.QemuMachine() as qm:
-            qm.run()
+        qm.run()
 
-            # expect qemu quit immediately with specific error message
-            _, err = qm.communicate()
-            assert "-accel kvm: vm-type tdx not supported by KVM" in err.decode()
+        # expect qemu quit immediately with specific error message
+        _, err = qm.communicate()
+        assert "-accel kvm: vm-type tdx not supported by KVM" in err.decode()
 
-def test_guest_disable_tdx_fail(release_kvm_use):
+def test_guest_disable_tdx_fail(qm, release_kvm_use):
     """
     tdx_disabled test case (See https://github.com/intel/tdx/wiki/Tests)
     """
 
     with KvmIntelModuleReloader('tdx=0') as module:
         # Run Qemu and verify failure
-        with Qemu.QemuMachine() as qm:
-            qm.run()
+        qm.run()
 
-            # expect qemu quit immediately with specific error message
-            _, err = qm.communicate()
-            assert "-accel kvm: vm-type tdx not supported by KVM" in err.decode()
+        # expect qemu quit immediately with specific error message
+        _, err = qm.communicate()
+        assert "-accel kvm: vm-type tdx not supported by KVM" in err.decode()
 
 class KvmIntelModuleReloader:
     """

--- a/tests/tests/test_guest_fail.py
+++ b/tests/tests/test_guest_fail.py
@@ -27,7 +27,7 @@ import util
 
 script_path=os.path.dirname(os.path.realpath(__file__))
 
-def test_guest_noept_fail():
+def test_guest_noept_fail(release_kvm_use):
     """
     tdx_NOEPT test case (See https://github.com/intel/tdx/wiki/Tests)
     """
@@ -49,26 +49,26 @@ def test_guest_noept_fail():
         assert dmesg_end_count == dmesg_start_count+1, "dmesg missing proper message"
 
         # Run Qemu and verify failure
-        qm = Qemu.QemuMachine()
-        qm.run()
+        with Qemu.QemuMachine() as qm:
+            qm.run()
 
-        # expect qemu quit immediately with specific error message
-        _, err = qm.communicate()
-        assert "-accel kvm: vm-type tdx not supported by KVM" in err.decode()
+            # expect qemu quit immediately with specific error message
+            _, err = qm.communicate()
+            assert "-accel kvm: vm-type tdx not supported by KVM" in err.decode()
 
-def test_guest_disable_tdx_fail():
+def test_guest_disable_tdx_fail(release_kvm_use):
     """
     tdx_disabled test case (See https://github.com/intel/tdx/wiki/Tests)
     """
 
     with KvmIntelModuleReloader('tdx=0') as module:
         # Run Qemu and verify failure
-        qm = Qemu.QemuMachine()
-        qm.run()
+        with Qemu.QemuMachine() as qm:
+            qm.run()
 
-        # expect qemu quit immediately with specific error message
-        _, err = qm.communicate()
-        assert "-accel kvm: vm-type tdx not supported by KVM" in err.decode()
+            # expect qemu quit immediately with specific error message
+            _, err = qm.communicate()
+            assert "-accel kvm: vm-type tdx not supported by KVM" in err.decode()
 
 class KvmIntelModuleReloader:
     """
@@ -81,4 +81,6 @@ class KvmIntelModuleReloader:
         subprocess.check_call('sudo rmmod kvm_intel', shell=True)
         subprocess.check_call(f'sudo modprobe kvm_intel {self.args}', shell=True)
     def __exit__(self, exc_type, exc_value, exc_tb):
+        # reload the kvm_intel
+        subprocess.check_call('sudo rmmod kvm_intel', shell=True)
         subprocess.check_call('sudo modprobe kvm_intel', shell=True)

--- a/tests/tests/test_guest_measurement.py
+++ b/tests/tests/test_guest_measurement.py
@@ -28,14 +28,14 @@ def test_guest_measurement_check_rtmr():
     """
     Boot measurements check
     """
-    qm = Qemu.QemuMachine()
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        qm.run()
 
-    m = Qemu.QemuSSH(qm)
+        m = Qemu.QemuSSH(qm)
 
-    deploy_and_setup(m)
+        deploy_and_setup(m)
 
-    m.check_exec('tdrtmrcheck')
+        m.check_exec('tdrtmrcheck')
 
-    qm.stop()
+        qm.stop()
 

--- a/tests/tests/test_guest_measurement.py
+++ b/tests/tests/test_guest_measurement.py
@@ -24,18 +24,17 @@ import Qemu
 import util
 from common import *
 
-def test_guest_measurement_check_rtmr():
+def test_guest_measurement_check_rtmr(qm):
     """
     Boot measurements check
     """
-    with Qemu.QemuMachine() as qm:
-        qm.run()
+    qm.run()
 
-        m = Qemu.QemuSSH(qm)
+    m = Qemu.QemuSSH(qm)
 
-        deploy_and_setup(m)
+    deploy_and_setup(m)
 
-        m.check_exec('tdrtmrcheck')
+    m.check_exec('tdrtmrcheck')
 
-        qm.stop()
+    qm.stop()
 

--- a/tests/tests/test_guest_report.py
+++ b/tests/tests/test_guest_report.py
@@ -24,17 +24,16 @@ import Qemu
 import util
 from common import *
 
-def test_guest_report():
+def test_guest_report(qm):
     """
     Boot measurements check
     """
-    with Qemu.QemuMachine() as qm:
-        qm.run()
+    qm.run()
 
-        m = Qemu.QemuSSH(qm)
+    m = Qemu.QemuSSH(qm)
 
-        deploy_and_setup(m)
+    deploy_and_setup(m)
 
-        m.check_exec(f'python3 {guest_workdir}/tests/guest/test_tdreport.py')
+    m.check_exec(f'python3 {guest_workdir}/tests/guest/test_tdreport.py')
 
-        qm.stop()
+    qm.stop()

--- a/tests/tests/test_guest_report.py
+++ b/tests/tests/test_guest_report.py
@@ -28,13 +28,13 @@ def test_guest_report():
     """
     Boot measurements check
     """
-    qm = Qemu.QemuMachine()
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        qm.run()
 
-    m = Qemu.QemuSSH(qm)
+        m = Qemu.QemuSSH(qm)
 
-    deploy_and_setup(m)
+        deploy_and_setup(m)
 
-    m.check_exec(f'python3 {guest_workdir}/tests/guest/test_tdreport.py')
+        m.check_exec(f'python3 {guest_workdir}/tests/guest/test_tdreport.py')
 
-    qm.stop()
+        qm.stop()

--- a/tests/tests/test_guest_tsc_config.py
+++ b/tests/tests/test_guest_tsc_config.py
@@ -42,27 +42,27 @@ def test_guest_tsc_config():
     # calculate tsc value
     tsc_host = ecx * ebx / eax
 
-    qm = Qemu.QemuMachine()
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        qm.run()
 
-    # Get cpuid value from guest and parse it
-    m = Qemu.QemuSSH(qm)
-    out_str = ''
-    [outlines, err] = m.check_exec('cpuid -rl 0x15 -1')
-    for l in outlines.readlines():
-        out_str += l
-    eax, ebx, ecx, edx = parse_cpuid_0x15_values(out_str)
+        # Get cpuid value from guest and parse it
+        m = Qemu.QemuSSH(qm)
+        out_str = ''
+        [outlines, err] = m.check_exec('cpuid -rl 0x15 -1')
+        for l in outlines.readlines():
+            out_str += l
+        eax, ebx, ecx, edx = parse_cpuid_0x15_values(out_str)
 
-    # calculate tsc value on guest and make sure same as host
-    tsc_guest = ecx * ebx / eax
-    assert tsc_guest == tsc_host, "TSC host and guest don't match"
+        # calculate tsc value on guest and make sure same as host
+        tsc_guest = ecx * ebx / eax
+        assert tsc_guest == tsc_host, "TSC host and guest don't match"
 
-    # Verify tsc detected in guest dmesg logs
-    stdout, _ = m.check_exec('dmesg')
-    output = stdout.read().decode('utf-8')
-    assert 'tsc: Detected' in output
+        # Verify tsc detected in guest dmesg logs
+        stdout, _ = m.check_exec('dmesg')
+        output = stdout.read().decode('utf-8')
+        assert 'tsc: Detected' in output
 
-    qm.stop()
+        qm.stop()
 
 
 def test_guest_set_tsc_frequency():
@@ -72,21 +72,21 @@ def test_guest_set_tsc_frequency():
 
     # Set guest tsc frequency
     tsc_frequency = 3000000000
-    qm = Qemu.QemuMachine()
-    qm.qcmd.plugins['cpu'].cpu_flags += f',tsc-freq={tsc_frequency}'
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        qm.qcmd.plugins['cpu'].cpu_flags += f',tsc-freq={tsc_frequency}'
+        qm.run()
 
-    # Get cpuid value from guest and parse it
-    m = Qemu.QemuSSH(qm)
-    out_str = ''
-    [outlines, err] = m.check_exec('cpuid -rl 0x15 -1')
-    for l in outlines.readlines():
-        out_str += l
-    eax, ebx, ecx, edx = parse_cpuid_0x15_values(out_str)
+        # Get cpuid value from guest and parse it
+        m = Qemu.QemuSSH(qm)
+        out_str = ''
+        [outlines, err] = m.check_exec('cpuid -rl 0x15 -1')
+        for l in outlines.readlines():
+            out_str += l
+        eax, ebx, ecx, edx = parse_cpuid_0x15_values(out_str)
 
-    # calculate tsc on guest and make sure its equal to value set
-    tsc_guest = ecx * ebx / eax
-    assert tsc_guest == tsc_frequency, "TSC frequency not set correctly"
+        # calculate tsc on guest and make sure its equal to value set
+        tsc_guest = ecx * ebx / eax
+        assert tsc_guest == tsc_frequency, "TSC frequency not set correctly"
 
 def test_guest_tsc_deadline_enable():
     """
@@ -108,18 +108,18 @@ def test_guest_tsc_deadline_disable():
     """
     tdx_tsc_deadline_disable test case (See https://github.com/intel/tdx/wiki/Tests)
     """
-    qm = Qemu.QemuMachine()
-    qm.qcmd.plugins['cpu'].cpu_flags += f',-tsc-deadline'
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        qm.qcmd.plugins['cpu'].cpu_flags += f',-tsc-deadline'
+        qm.run()
 
-    m = Qemu.QemuSSH(qm)
+        m = Qemu.QemuSSH(qm)
 
-    stdout, _ = m.check_exec('lscpu')
-    output = stdout.read().decode('utf-8')
-    assert 'Flags' in output
-    assert 'tsc_deadline_timer' not in output
+        stdout, _ = m.check_exec('lscpu')
+        output = stdout.read().decode('utf-8')
+        assert 'Flags' in output
+        assert 'tsc_deadline_timer' not in output
 
-    qm.stop()
+        qm.stop()
 
 # helper function for parsing cpuid value into registers
 def parse_cpuid_0x15_values(val_str):

--- a/tests/tests/test_nmi_debug_off.py
+++ b/tests/tests/test_nmi_debug_off.py
@@ -19,11 +19,10 @@ import Qemu
 
 # Tests
 
-def test_nmi_debug_off():
+def test_nmi_debug_off(qm):
     """
     Boot TDX VM and make sure nmi runs without issue in monitor (Intel Case ID: 006)
     """
-    qm = Qemu.QemuMachine()
     qm.run()
 
     mon = Qemu.QemuMonitor(qm)

--- a/tests/tests/test_perf_boot_time.py
+++ b/tests/tests/test_perf_boot_time.py
@@ -41,6 +41,7 @@ def test_boot_time(name, machine, memory):
         qm.run()
         m = Qemu.QemuSSH(qm, timeout=200)
 
-    util.timeit(boot_vm_and_wait_ssh)()
+    with qm:
+        util.timeit(boot_vm_and_wait_ssh)()
 
-    qm.stop()
+        qm.stop()

--- a/tests/tests/test_quote_configfs_tsm.py
+++ b/tests/tests/test_quote_configfs_tsm.py
@@ -27,16 +27,16 @@ def test_quote_check_configfs_tsm():
     """
     Check that the configfs tsm for quote generation is available
     """
-    qm = Qemu.QemuMachine()
-    qm.run()
+    with Qemu.QemuMachine() as qm:
+        qm.run()
 
-    m = Qemu.QemuSSH(qm)
+        m = Qemu.QemuSSH(qm)
 
-    deploy_and_setup(m)
+        deploy_and_setup(m)
 
-    m.check_exec('tdtsmcheck')
+        m.check_exec('tdtsmcheck')
 
-    qm.stop()
+        qm.stop()
 
 def test_qgs_socket():
     """
@@ -54,4 +54,3 @@ def test_qgs_socket():
     ssh.check_exec('tdtsmcheck')
 
     qm.stop()
-

--- a/tests/tests/test_quote_configfs_tsm.py
+++ b/tests/tests/test_quote_configfs_tsm.py
@@ -23,29 +23,27 @@ from common import deploy_and_setup
 
 script_path=os.path.dirname(os.path.realpath(__file__))
 
-def test_quote_check_configfs_tsm():
+def test_quote_check_configfs_tsm(qm):
     """
     Check that the configfs tsm for quote generation is available
     """
-    with Qemu.QemuMachine() as qm:
-        qm.run()
+    qm.run()
 
-        m = Qemu.QemuSSH(qm)
+    m = Qemu.QemuSSH(qm)
 
-        deploy_and_setup(m)
+    deploy_and_setup(m)
 
-        m.check_exec('tdtsmcheck')
+    m.check_exec('tdtsmcheck')
 
-        qm.stop()
+    qm.stop()
 
-def test_qgs_socket():
+def test_qgs_socket(qm):
     """
     Test QGS socket (No Intel Case ID)
     """
     object = '{"qom-type":"tdx-guest","id":"tdx","quote-generation-socket":{"type": "vsock", "cid":"2","port":"4050"}}'
     Qemu.QemuMachineType.Qemu_Machine_Params[Qemu.QemuEfiMachine.OVMF_Q35_TDX][1] = object
 
-    qm = Qemu.QemuMachine()
     qm.run()
 
     # do basic tsm_config test on guest

--- a/tests/tests/test_stress_boot.py
+++ b/tests/tests/test_stress_boot.py
@@ -28,7 +28,7 @@ def test_boot():
     """
     for i in range(0,100):
         print(f'\nBooting TD nb={i}')
-        qm = Qemu.QemuMachine()
-        qm.run()
-        m = Qemu.QemuSSH(qm)
-        qm.stop()
+        with Qemu.QemuMachine() as qm:
+            qm.run()
+            m = Qemu.QemuSSH(qm)
+            qm.stop()

--- a/tests/tests/test_stress_resources.py
+++ b/tests/tests/test_stress_resources.py
@@ -21,7 +21,7 @@ import multiprocessing
 import Qemu
 import util
 
-def test_huge_resource_vm():
+def test_huge_resource_vm(qm):
     """
     Test huge resources  (Intel Case ID 007)
     """
@@ -30,7 +30,6 @@ def test_huge_resource_vm():
     huge_mem_gb = int(util.get_memory_free_gb() / 2)
     num_cpus = int(multiprocessing.cpu_count() / 2)
 
-    qm = Qemu.QemuMachine()
     qm.qcmd.plugins['cpu'].nb_cores = num_cpus
     qm.qcmd.plugins['memory'].memory = '%dG' % (huge_mem_gb)
     qm.run()
@@ -39,7 +38,7 @@ def test_huge_resource_vm():
 
     qm.stop()
 
-def test_memory_limit_resource_vm():
+def test_memory_limit_resource_vm(qm):
     """
     Test memory limit resource  (No Intel Case)
     """
@@ -47,7 +46,6 @@ def test_memory_limit_resource_vm():
     # choose half available memory per Intel case spec
     huge_mem_gb = int(util.get_memory_available_gb())
 
-    qm = Qemu.QemuMachine()
     qm.qcmd.plugins['memory'].memory = '%dG' % (huge_mem_gb)
     qm.run()
 
@@ -56,7 +54,7 @@ def test_memory_limit_resource_vm():
     qm.stop()
 
 
-def test_max_vcpus():
+def test_max_vcpus(qm):
     """
     Test max vcpus (No Intel Case ID)
     """
@@ -64,7 +62,6 @@ def test_max_vcpus():
     if num_cpus > 255:
         num_cpus = 255 # max possible right now
 
-    qm = Qemu.QemuMachine()
     qm.qcmd.plugins['cpu'].nb_cores = num_cpus
     qm.run()
 

--- a/tests/tests/test_vsock_vm.py
+++ b/tests/tests/test_vsock_vm.py
@@ -41,11 +41,10 @@ def run_iperf_server_on_guest(ssh):
 
 # Tests
 
-def test_vsock_vm_client():
+def test_vsock_vm_client(qm):
     """
     vsock vm guest client and host as server (Intel Case ID: 028)
     """
-    qm = Qemu.QemuMachine()
     qm.qcmd.add_vsock(guest_cid)
     qm.run()
 
@@ -63,11 +62,10 @@ def test_vsock_vm_client():
     qm.stop()
 
 
-def test_vsock_vm_server():
+def test_vsock_vm_server(qm):
     """
     vsock vm guest server and host as client (Intel Case ID: 027)
     """
-    qm = Qemu.QemuMachine()
     qm.qcmd.add_vsock(guest_cid)
     qm.run()
 


### PR DESCRIPTION
each test usually runs a qemu process, for several reasons (test badly written, test failure, ...), the qemu process can still be running after the test and this might block some tests on reloading the kvm kernel module (because it is used) this commit aims to provide several tools:
  - qemu machine as a context manager when we write a test and needs to create a qemu machine, we can use the context manager to make sure that the machine is released at the end of the test (even on failure)
  - test fixture that cleans up all running qemu instances, each test can request this fixture in the test argument so that before the test start, all running qemu are stopped.
  
  - Fixes #225 