### PR TITLE
test_guest_cpu_off: fixes failure

### DIFF
--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 import Qemu
+import util
 
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests(tmpdir):
@@ -41,3 +42,12 @@ def qm():
     """
     with Qemu.QemuMachine() as qm:
         yield qm
+
+@pytest.fixture()
+def cpu_core():
+    """
+    Fixture to create CPU core manager
+    """
+    cpu = util.cpu_select()
+    with util.CpuOnOff(cpu) as cpu:
+        yield cpu

--- a/tests/tests/test_guest_fail.py
+++ b/tests/tests/test_guest_fail.py
@@ -78,6 +78,7 @@ class KvmIntelModuleReloader:
     def __enter__(self):
         subprocess.check_call('sudo rmmod kvm_intel', shell=True)
         subprocess.check_call(f'sudo modprobe kvm_intel {self.args}', shell=True)
+        return self
     def __exit__(self, exc_type, exc_value, exc_tb):
         # reload the kvm_intel
         subprocess.check_call('sudo rmmod kvm_intel', shell=True)


### PR DESCRIPTION
- if we pin the process to a offline cpu core, the test will fail we need to bring the core online fist
- add a cpu manager as context manager to easily restore the core state at the end of the test
- move some utility code to util.py
- make cpu random select more robust since on some systems core0 might not support the on/off feature (IRQ is wired on it)