### PR TITLE
test_guest_early_printk : test with the kernel in the guest VM

### DIFF
--- a/tests/lib/Qemu.py
+++ b/tests/lib/Qemu.py
@@ -578,6 +578,19 @@ class QemuMachine:
             except Exception as e:
                 print(f'Exception {e}')
 
+    def reboot(self):
+        """
+        Reboot the QEMU machine
+        Since VM might not support reboot just poweroff and start gain
+        """
+        m = QemuSSH(self)
+        # sync data and poweroff
+        m.check_exec('sync && systemctl poweroff')
+        # check that VM quits properly
+        self.communicate()
+        # run the VM again
+        self.run()
+
     def __del__(self):
         """
         Make sure we stop the qemu process if it is still running


### PR DESCRIPTION
right now, we are testing the host kernel
actually, we want to do this test for the guest VM kernel
I propose to fix that by redesigning the test in 2 steps:
  - append the wanted kernel commandline in the guest VM
  - restart the guest VM