### PR TITLE
system-report : fix too long output for GH issue

### DIFF
--- a/system-report.sh
+++ b/system-report.sh
@@ -90,7 +90,9 @@ print_section "Operating system details" "${result}"
 result=$(uname -rvpio) # show everything but hostname
 print_section "Kernel version" "${result}"
 
-result=$(sudo dmesg | grep -i tdx)
+dmesg_head=$(sudo dmesg | grep -i tdx | head -n 10)
+dmesg_tail=$(sudo dmesg | grep -i tdx | tail -n 20)
+result="${dmesg_head}\n...\n${dmesg_tail}"
 print_section "TDX kernel logs" "${result}"
 
 result=$( \


### PR DESCRIPTION
GH issue accepts comments with length less than 65k characters with dmesg output, if the machine is up and running for a quite long period it can generate very long  output

To mitigate this issue, we limits the dmesg output to the first 10 lines and 20 last lines only. The first 10 lines allow us to see the tdx module load and the 20 last lines might show us the log that happens during the issue