### PR TITLE
Kexec/Kdump Tests

### DIFF
--- a/tests/tests/test_host_kdump.sh
+++ b/tests/tests/test_host_kdump.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/bash
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# sudo apt install linux-crashdump
+# reboot
+# kdump-config show
+# cat /proc/cmdline --> verify crashkernel value in place 
+# validate cat /proc/sys/kernel/sysrq > 0
+# trigger crash --> sudo "echo c > /proc/sysrq-trigger"
+# find crashdump in /var/crash
+
+if [ ! -v DEVICE_IP ]; then
+    DEVICE_IP="192.168.102.125"
+fi
+
+echo "Installing linux-crashdump and rebooting"
+ssh ubuntu@$DEVICE_IP sudo apt install linux-crashdump
+if [ $? != 0 ]; then
+    echo "Can't install linux-crashdump"
+    exit -1
+fi
+
+ssh ubuntu@$DEVICE_IP sudo systemctl reboot
+if [ $? != 0 ]; then
+    echo "Can't reboot"
+    exit -2
+fi
+
+sleep 30
+echo "Waiting for system to come back up"
+
+cnt=0
+until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
+if [ $cnt -gt 60 ]; then
+    echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
+    exit -3
+fi
+if [ $cnt == 0 ]; then
+    echo "$DEVICE_IP came back too quickly"
+    exit -4
+fi
+
+echo "System came back up"
+
+KDUMP_CONFIG="$(ssh ubuntu@$DEVICE_IP sudo kdump-config show)"
+if [ $? != 0 ]; then
+    echo "Failed getting kdump config"
+    exit -5
+fi
+
+CMDLINE="$(ssh ubuntu@$DEVICE_IP cat /proc/cmdline)"
+if [ $? != 0 ]; then
+    echo "Failed getting cmd line"
+    exit -6
+fi
+
+CRASH_DIR="$(ssh ubuntu@$DEVICE_IP ls /var/crash)"
+if [ $? != 0 ]; then
+    echo "Failed getting crash directory"
+    exit -7
+fi
+
+
+echo "Crashing system"
+ssh ubuntu@$DEVICE_IP "echo c | sudo tee /proc/sysrq-trigger" &
+
+sleep 10
+echo "Waiting for system to come back up"
+
+cnt=0
+until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
+if [ $cnt -gt 60 ]; then
+    echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
+    exit -9
+fi
+if [ $cnt == 0 ]; then
+    echo "$DEVICE_IP came back too quickly"
+    exit -10
+fi
+
+echo "System came back up"
+CRASH_DIR2="$(ssh ubuntu@$DEVICE_IP ls /var/crash)"
+if [ $? != 0 ]; then
+    echo "Failed getting crash directory"
+    exit -11
+fi
+
+echo $CRASH_DIR
+echo "----------------------------------------------------"
+echo "----------------------------------------------------"
+echo "----------------------------------------------------"
+echo $CRASH_DIR2

--- a/tests/tests/test_host_kdump.sh
+++ b/tests/tests/test_host_kdump.sh
@@ -17,7 +17,7 @@
 
 if [ ! -v DEVICE_IP ]; then
     echo "Must define DEVICE_IP"
-    exit -13
+    exit -1
 fi
 
 echo "Installing linux-crashdump and rebooting"
@@ -30,7 +30,7 @@ fi
 ssh ubuntu@$DEVICE_IP sudo systemctl reboot
 if [ $? != 0 ]; then
     echo "Can't reboot"
-    exit -2
+    exit -1
 fi
 
 sleep 15
@@ -40,11 +40,11 @@ cnt=0
 until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
 if [ $cnt -gt 120 ]; then
     echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
-    exit -3
+    exit -1
 fi
 if [ $cnt == 0 ]; then
     echo "$DEVICE_IP came back too quickly"
-    exit -4
+    exit -1
 fi
 
 echo "System came back up, printing out useful debug info"
@@ -52,20 +52,20 @@ echo "System came back up, printing out useful debug info"
 ssh ubuntu@$DEVICE_IP sudo kdump-config show
 if [ $? != 0 ]; then
     echo "Failed getting kdump config"
-    exit -5
+    exit -1
 fi
 
 ssh ubuntu@$DEVICE_IP cat /proc/cmdline
 if [ $? != 0 ]; then
     echo "Failed getting cmd line"
-    exit -6
+    exit -1
 fi
 
 # Get crash directory before to compare later
 CRASH_DIR_BEFORE="$(ssh ubuntu@$DEVICE_IP ls /var/crash)"
 if [ $? != 0 ]; then
     echo "Failed getting crash directory"
-    exit -7
+    exit -1
 fi
 
 echo "Crashing system"
@@ -78,18 +78,18 @@ cnt=0
 until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
 if [ $cnt -gt 120 ]; then
     echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
-    exit -9
+    exit -1
 fi
 if [ $cnt == 0 ]; then
     echo "$DEVICE_IP came back too quickly"
-    exit -10
+    exit -1
 fi
 
 echo "System came back up"
 CRASH_DIR_AFTER="$(ssh ubuntu@$DEVICE_IP ls /var/crash)"
 if [ $? != 0 ]; then
     echo "Failed getting crash directory"
-    exit -11
+    exit -1
 fi
 
 echo Before crash directory listing: $CRASH_DIR_BEFORE
@@ -98,7 +98,7 @@ echo After crash directory listing: $CRASH_DIR_AFTER
 # Verifyng crash directory are not the same (extra entry should be in place)
 if [ "$CRASH_DIR_BEFORE" == "$CRASH_DIR_AFTER" ]; then
     echo "Crash directories are the same"
-    exit -12
+    exit -1
 fi
 
 echo "Kdump Successfully Performed"

--- a/tests/tests/test_host_kdump.sh
+++ b/tests/tests/test_host_kdump.sh
@@ -24,48 +24,66 @@ fi
 
 echo "Installing linux-crashdump and rebooting"
 set -e
-ssh ubuntu@$DEVICE_IP sudo apt install linux-crashdump
-ssh ubuntu@$DEVICE_IP sudo systemctl reboot
-sleep 15
+ssh $SSH_OPTIONS ubuntu@$DEVICE_IP sudo apt install linux-crashdump
+ssh $SSH_OPTIONS ubuntu@$DEVICE_IP sudo systemctl reboot
+
+echo "Waiting for system to go down"
+cnt=0
+until ! ssh -o ConnectTimeout=2 $SSH_OPTIONS ubuntu@$DEVICE_IP ls &> /dev/null; do 
+    sleep 1; 
+    cnt=$(expr $cnt + 1);
+    if [ $cnt -gt 30 ]; then
+        echo "$DEVICE_IP did not reboot"
+        exit 1
+    fi
+done
 
 echo "Waiting for system to come back up"
 cnt=0
-until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
-if [ $cnt -gt 120 ]; then
-    echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
-    exit 1
-fi
-if [ $cnt == 0 ]; then
-    echo "$DEVICE_IP came back quickly, likely did not reboot as expected"
-    exit 1
-fi
+until ssh -o ConnectTimeout=2 $SSH_OPTIONS ubuntu@$DEVICE_IP ls &> /dev/null; do 
+    sleep 1; 
+    cnt=$(expr $cnt + 1); 
+    if [ $cnt -gt 120 ]; then
+        echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
+        exit 1
+    fi
+done
 
 echo "System came back up, printing out useful debug info"
 
-ssh ubuntu@$DEVICE_IP sudo kdump-config show
-ssh ubuntu@$DEVICE_IP cat /proc/cmdline
+ssh $SSH_OPTIONS ubuntu@$DEVICE_IP sudo kdump-config show
+ssh $SSH_OPTIONS ubuntu@$DEVICE_IP cat /proc/cmdline
 
 # Get crash directory before to compare later
 CRASH_DIR_BEFORE="$(ssh ubuntu@$DEVICE_IP ls /var/crash)"
 
 echo "Crashing system"
-ssh ubuntu@$DEVICE_IP "echo c | sudo tee /proc/sysrq-trigger" > /dev/null &
-sleep 10
+ssh $SSH_OPTIONS ubuntu@$DEVICE_IP "echo c | sudo tee /proc/sysrq-trigger" > /dev/null &
+
+echo "Waiting for system to go down"
+cnt=0
+until ! ssh -o ConnectTimeout=2 $SSH_OPTIONS ubuntu@$DEVICE_IP ls &> /dev/null; do 
+    sleep 1; 
+    cnt=$(expr $cnt + 1); 
+    if [ $cnt -gt 30 ]; then 
+        echo "$DEVICE_IP did not reboot"
+        exit 1
+    fi
+done
 
 echo "Waiting for system to come back up"
 cnt=0
-until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
-if [ $cnt -gt 120 ]; then
-    echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
-    exit 1
-fi
-if [ $cnt == 0 ]; then
-    echo "$DEVICE_IP came back quickly, likely did not crash as expected"
-    exit 1
-fi
+until ssh -o ConnectTimeout=2 $SSH_OPTIONS ubuntu@$DEVICE_IP ls &> /dev/null; do 
+    sleep 1; 
+    cnt=$(expr $cnt + 1); 
+    if [ $cnt -gt 120 ]; then
+        echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
+        exit 1
+    fi
+done
 
 echo "System came back up"
-CRASH_DIR_AFTER="$(ssh ubuntu@$DEVICE_IP ls /var/crash)"
+CRASH_DIR_AFTER="$(ssh $SSH_OPTIONS ubuntu@$DEVICE_IP ls /var/crash)"
 echo Before crash directory listing: $CRASH_DIR_BEFORE
 echo After crash directory listing: $CRASH_DIR_AFTER
 

--- a/tests/tests/test_host_kdump.sh
+++ b/tests/tests/test_host_kdump.sh
@@ -16,7 +16,8 @@
 #
 
 if [ ! -v DEVICE_IP ]; then
-    DEVICE_IP="192.168.102.125"
+    echo "Must define DEVICE_IP"
+    exit -13
 fi
 
 echo "Installing linux-crashdump and rebooting"
@@ -32,12 +33,12 @@ if [ $? != 0 ]; then
     exit -2
 fi
 
-sleep 30
+sleep 15
 echo "Waiting for system to come back up"
 
 cnt=0
 until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
-if [ $cnt -gt 60 ]; then
+if [ $cnt -gt 120 ]; then
     echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
     exit -3
 fi
@@ -75,7 +76,7 @@ echo "Waiting for system to come back up"
 
 cnt=0
 until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
-if [ $cnt -gt 60 ]; then
+if [ $cnt -gt 120 ]; then
     echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
     exit -9
 fi

--- a/tests/tests/test_host_kdump.sh
+++ b/tests/tests/test_host_kdump.sh
@@ -15,90 +15,64 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+SSH_OPTIONS=" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
 if [ ! -v DEVICE_IP ]; then
     echo "Must define DEVICE_IP"
-    exit -1
+    exit 1
 fi
 
 echo "Installing linux-crashdump and rebooting"
+set -e
 ssh ubuntu@$DEVICE_IP sudo apt install linux-crashdump
-if [ $? != 0 ]; then
-    echo "Can't install linux-crashdump"
-    exit -1
-fi
-
 ssh ubuntu@$DEVICE_IP sudo systemctl reboot
-if [ $? != 0 ]; then
-    echo "Can't reboot"
-    exit -1
-fi
-
 sleep 15
-echo "Waiting for system to come back up"
 
+echo "Waiting for system to come back up"
 cnt=0
 until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
 if [ $cnt -gt 120 ]; then
     echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
-    exit -1
+    exit 1
 fi
 if [ $cnt == 0 ]; then
-    echo "$DEVICE_IP came back too quickly"
-    exit -1
+    echo "$DEVICE_IP came back quickly, likely did not reboot as expected"
+    exit 1
 fi
 
 echo "System came back up, printing out useful debug info"
 
 ssh ubuntu@$DEVICE_IP sudo kdump-config show
-if [ $? != 0 ]; then
-    echo "Failed getting kdump config"
-    exit -1
-fi
-
 ssh ubuntu@$DEVICE_IP cat /proc/cmdline
-if [ $? != 0 ]; then
-    echo "Failed getting cmd line"
-    exit -1
-fi
 
 # Get crash directory before to compare later
 CRASH_DIR_BEFORE="$(ssh ubuntu@$DEVICE_IP ls /var/crash)"
-if [ $? != 0 ]; then
-    echo "Failed getting crash directory"
-    exit -1
-fi
 
 echo "Crashing system"
 ssh ubuntu@$DEVICE_IP "echo c | sudo tee /proc/sysrq-trigger" > /dev/null &
-
 sleep 10
-echo "Waiting for system to come back up"
 
+echo "Waiting for system to come back up"
 cnt=0
 until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
 if [ $cnt -gt 120 ]; then
     echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
-    exit -1
+    exit 1
 fi
 if [ $cnt == 0 ]; then
-    echo "$DEVICE_IP came back too quickly"
-    exit -1
+    echo "$DEVICE_IP came back quickly, likely did not crash as expected"
+    exit 1
 fi
 
 echo "System came back up"
 CRASH_DIR_AFTER="$(ssh ubuntu@$DEVICE_IP ls /var/crash)"
-if [ $? != 0 ]; then
-    echo "Failed getting crash directory"
-    exit -1
-fi
-
 echo Before crash directory listing: $CRASH_DIR_BEFORE
 echo After crash directory listing: $CRASH_DIR_AFTER
 
-# Verifyng crash directory are not the same (extra entry should be in place)
+# Verifying crash directory are not the same (extra entry should be in place)
 if [ "$CRASH_DIR_BEFORE" == "$CRASH_DIR_AFTER" ]; then
     echo "Crash directories are the same"
-    exit -1
+    exit 1
 fi
 
 echo "Kdump Successfully Performed"

--- a/tests/tests/test_host_kdump.sh
+++ b/tests/tests/test_host_kdump.sh
@@ -15,14 +15,6 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# sudo apt install linux-crashdump
-# reboot
-# kdump-config show
-# cat /proc/cmdline --> verify crashkernel value in place 
-# validate cat /proc/sys/kernel/sysrq > 0
-# trigger crash --> sudo "echo c > /proc/sysrq-trigger"
-# find crashdump in /var/crash
-
 if [ ! -v DEVICE_IP ]; then
     DEVICE_IP="192.168.102.125"
 fi
@@ -54,7 +46,7 @@ if [ $cnt == 0 ]; then
     exit -4
 fi
 
-echo "System came back up"
+echo "System came back up, printing out useful debug info"
 
 ssh ubuntu@$DEVICE_IP sudo kdump-config show
 if [ $? != 0 ]; then
@@ -68,6 +60,7 @@ if [ $? != 0 ]; then
     exit -6
 fi
 
+# Get crash directory before to compare later
 CRASH_DIR_BEFORE="$(ssh ubuntu@$DEVICE_IP ls /var/crash)"
 if [ $? != 0 ]; then
     echo "Failed getting crash directory"
@@ -75,7 +68,7 @@ if [ $? != 0 ]; then
 fi
 
 echo "Crashing system"
-ssh ubuntu@$DEVICE_IP "echo c | sudo tee /proc/sysrq-trigger" &
+ssh ubuntu@$DEVICE_IP "echo c | sudo tee /proc/sysrq-trigger" > /dev/null &
 
 sleep 10
 echo "Waiting for system to come back up"
@@ -101,10 +94,10 @@ fi
 echo Before crash directory listing: $CRASH_DIR_BEFORE
 echo After crash directory listing: $CRASH_DIR_AFTER
 
-# Verifyng crash directory are not the same (extra entry in place)
+# Verifyng crash directory are not the same (extra entry should be in place)
 if [ "$CRASH_DIR_BEFORE" == "$CRASH_DIR_AFTER" ]; then
     echo "Crash directories are the same"
     exit -12
 fi
 
-echo "Success!"
+echo "Kdump Successfully Performed"

--- a/tests/tests/test_host_kexec.sh
+++ b/tests/tests/test_host_kexec.sh
@@ -17,7 +17,7 @@
 
 if [ ! -v DEVICE_IP ]; then
     echo "Must define DEVICE_IP"
-    exit -13
+    exit -1
 fi
 
 echo "Getting information for kexec call"
@@ -35,20 +35,20 @@ fi
 ssh ubuntu@$DEVICE_IP ls $INITRD > /dev/null
 if [ $? != 0 ]; then
     echo "Can't find $INITRD"
-    exit -2
+    exit -1
 fi
 
 CMDLINE="$(ssh ubuntu@$DEVICE_IP cat /proc/cmdline)"
 if [ $? != 0 ]; then
     echo "Failed getting command line"
-    exit -3
+    exit -1
 fi
 
 echo "Calling kexec: ssh ubuntu@$DEVICE_IP sudo kexec -l $KERNEL --initrd=$INITRD --command-line=\"$CMDLINE\""
 ssh ubuntu@$DEVICE_IP sudo kexec -l $KERNEL --initrd=$INITRD --command-line=\"$CMDLINE\"
 if [ $? != 0 ]; then
     echo "Failed kexec load: ssh ubuntu@$DEVICE_IP sudo kexec -l $KERNEL --initrd=$INITRD --command-line=\"$CMDLINE\""
-    exit -4
+    exit -1
 fi
 
 echo "Running kexec -e in background"
@@ -60,11 +60,11 @@ cnt=0
 until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
 if [ $cnt -gt 120 ]; then
     echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
-    exit -5
+    exit -1
 fi
 if [ $cnt == 0 ]; then
     echo "$DEVICE_IP came back too quickly"
-    exit -6
+    exit -1
 fi
 
 echo "Kexec Successfully Performed"

--- a/tests/tests/test_host_kexec.sh
+++ b/tests/tests/test_host_kexec.sh
@@ -67,5 +67,3 @@ if [ $cnt == 0 ]; then
 fi
 
 echo "Kexec Successfully Performed"
-
-

--- a/tests/tests/test_host_kexec.sh
+++ b/tests/tests/test_host_kexec.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 #
+# Copyright 2024 Canonical Ltd.
+#
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
 # by the Free Software Foundation.

--- a/tests/tests/test_host_kexec.sh
+++ b/tests/tests/test_host_kexec.sh
@@ -16,7 +16,8 @@
 #
 
 if [ ! -v DEVICE_IP ]; then
-    DEVICE_IP="192.168.102.125"
+    echo "Must define DEVICE_IP"
+    exit -13
 fi
 
 echo "Getting information for kexec call"
@@ -56,8 +57,8 @@ sleep 10
 echo "Waiting for system to come back up"
 
 cnt=0
-until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 60 ]; then break; fi; done
-if [ $cnt -gt 60 ]; then
+until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
+if [ $cnt -gt 120 ]; then
     echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
     exit -5
 fi

--- a/tests/tests/test_host_kexec.sh
+++ b/tests/tests/test_host_kexec.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/bash
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+if [ ! -v DEVICE_IP ]; then
+    DEVICE_IP="192.168.102.125"
+fi
+
+echo "Getting information for kexec call"
+
+UNAME_RELEASE="$(ssh ubuntu@$DEVICE_IP uname -r)"
+KERNEL="/boot/vmlinuz-$UNAME_RELEASE"
+INITRD="/boot/initrd.img-$UNAME_RELEASE"
+
+ssh ubuntu@$DEVICE_IP ls $KERNEL > /dev/null
+if [ $? != 0 ]; then
+    echo "Can't find $KERNEL"
+    exit -1
+fi
+
+ssh ubuntu@$DEVICE_IP ls $INITRD > /dev/null
+if [ $? != 0 ]; then
+    echo "Can't find $INITRD"
+    exit -2
+fi
+
+CMDLINE="$(ssh ubuntu@$DEVICE_IP cat /proc/cmdline)"
+if [ $? != 0 ]; then
+    echo "Failed getting command line"
+    exit -3
+fi
+
+echo "Calling kexec: ssh ubuntu@$DEVICE_IP sudo kexec -l $KERNEL --initrd=$INITRD --command-line=\"$CMDLINE\""
+ssh ubuntu@$DEVICE_IP sudo kexec -l $KERNEL --initrd=$INITRD --command-line=\"$CMDLINE\"
+if [ $? != 0 ]; then
+    echo "Failed kexec load: ssh ubuntu@$DEVICE_IP sudo kexec -l $KERNEL --initrd=$INITRD --command-line=\"$CMDLINE\""
+    exit -4
+fi
+
+echo "Running kexec -e in background"
+ssh ubuntu@$DEVICE_IP sudo kexec -e &
+sleep 10
+echo "Waiting for system to come back up"
+
+cnt=0
+until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 60 ]; then break; fi; done
+if [ $cnt -gt 60 ]; then
+    echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
+    exit -5
+fi
+if [ $cnt == 0 ]; then
+    echo "$DEVICE_IP came back too quickly"
+    exit -6
+fi
+
+echo "Kexec Successfully Performed"
+
+

--- a/tests/tests/test_host_kexec.sh
+++ b/tests/tests/test_host_kexec.sh
@@ -15,56 +15,40 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+SSH_OPTIONS=" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
 if [ ! -v DEVICE_IP ]; then
     echo "Must define DEVICE_IP"
-    exit -1
+    exit 1
 fi
 
+set -e
 echo "Getting information for kexec call"
-
 UNAME_RELEASE="$(ssh ubuntu@$DEVICE_IP uname -r)"
 KERNEL="/boot/vmlinuz-$UNAME_RELEASE"
 INITRD="/boot/initrd.img-$UNAME_RELEASE"
-
 ssh ubuntu@$DEVICE_IP ls $KERNEL > /dev/null
-if [ $? != 0 ]; then
-    echo "Can't find $KERNEL"
-    exit -1
-fi
-
 ssh ubuntu@$DEVICE_IP ls $INITRD > /dev/null
-if [ $? != 0 ]; then
-    echo "Can't find $INITRD"
-    exit -1
-fi
-
 CMDLINE="$(ssh ubuntu@$DEVICE_IP cat /proc/cmdline)"
-if [ $? != 0 ]; then
-    echo "Failed getting command line"
-    exit -1
-fi
 
 echo "Calling kexec: ssh ubuntu@$DEVICE_IP sudo kexec -l $KERNEL --initrd=$INITRD --command-line=\"$CMDLINE\""
 ssh ubuntu@$DEVICE_IP sudo kexec -l $KERNEL --initrd=$INITRD --command-line=\"$CMDLINE\"
-if [ $? != 0 ]; then
-    echo "Failed kexec load: ssh ubuntu@$DEVICE_IP sudo kexec -l $KERNEL --initrd=$INITRD --command-line=\"$CMDLINE\""
-    exit -1
-fi
 
 echo "Running kexec -e in background"
 ssh ubuntu@$DEVICE_IP sudo kexec -e &
 sleep 10
+
 echo "Waiting for system to come back up"
 
 cnt=0
 until ssh ubuntu@$DEVICE_IP ls &> /dev/null; do sleep 1; cnt=$(expr $cnt + 1); if [ $cnt -gt 120 ]; then break; fi; done
 if [ $cnt -gt 120 ]; then
     echo "Timed out waiting for $DEVICE_IP to come back up ($cnt)"
-    exit -1
+    exit 1
 fi
 if [ $cnt == 0 ]; then
     echo "$DEVICE_IP came back too quickly"
-    exit -1
+    exit 1
 fi
 
 echo "Kexec Successfully Performed"


### PR DESCRIPTION
https://warthogs.atlassian.net/browse/PEK-852

Adding kexec/kdump tests for the host.  This requires the host to be rebooted effectively multiple times.  So, this was written as a shell script that can be used, eventually, in testflinger, or in a runner.