### PR TITLE
add network to guest to make it accessible via IP  

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ TD, PID: 111924, SSH : ssh -p 10022 root@localhost
         1    tdvirsh-trust_domain-f7210c2b-2657-4f30-adf3-639b573ea39f   running (ip:192.168.122.212, hostfwd:32855, cid:3)
         ```
 
-        NOTE: `32855` in `hostfwd:32855` is the port number a user can use to connect to the TD via `ssh`.
+        NOTE: `32855` in `hostfwd:32855` is the port number a user can use to connect to the TD via `ssh -p 32855 root@localhost`.
+              You can also connect to the guest using its IP address : `ssh root@192.168.122.212`.
 
    * A TD can be removed with the following command:
 

--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ TD, PID: 111924, SSH : ssh -p 10022 root@localhost
         ```console
         Id   Name                                                        State
         ---------------------------------------------------------------------------
-        1    tdvirsh-trust_domain-f7210c2b-2657-4f30-adf3-639b573ea39f   running (ssh:32855, cid:3)
+        1    tdvirsh-trust_domain-f7210c2b-2657-4f30-adf3-639b573ea39f   running (ip:192.168.122.212, hostfwd:32855, cid:3)
         ```
 
-        NOTE: `32855` in `ssh:32855` is the port number a user can use to connect to the TD via `ssh`.
+        NOTE: `32855` in `hostfwd:32855` is the port number a user can use to connect to the TD via `ssh`.
 
    * A TD can be removed with the following command:
 

--- a/guest-tools/regular_vm.xml.template
+++ b/guest-tools/regular_vm.xml.template
@@ -36,6 +36,11 @@
       </backingStore>
       <target dev="vda" bus="virtio"/>
     </disk>
+    <interface type='network'>
+      <source network='default'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
+    </interface>
     <console type='pty'>
       <target type='virtio' port='1'/>
     </console>

--- a/guest-tools/tdvirsh
+++ b/guest-tools/tdvirsh
@@ -172,7 +172,11 @@ print_all() {
                     --hmp info qtree 2>&1 |
                     awk '/guest-cid/ {print $3}'
                      )
-            extra_info="(ssh:$host_port, cid:${guest_cid})"
+            host_ip=$(
+               virsh domifaddr ${td_domain}  |
+                    awk '/vnet/ {print $4}'
+                     )
+            extra_info="(ip:${host_ip}, ssh:$host_port, cid:${guest_cid})"
         fi
         echo "$line $extra_info"
     done < <(virsh "list --all")

--- a/guest-tools/tdvirsh
+++ b/guest-tools/tdvirsh
@@ -176,7 +176,12 @@ print_all() {
                virsh domifaddr ${td_domain} 2>&1 |
                     awk '/vnet/ {print $4}'
                      )
-            extra_info="(ip:${host_ip}, ssh:$host_port, cid:${guest_cid})"
+            if [[ "${host_ip}" != */* ]]; then
+                host_ip="unknown"
+            else
+                host_ip="${host_ip%/*}"
+            fi
+            extra_info="(ip:${host_ip}, hostfwd:$host_port, cid:${guest_cid})"
         fi
         echo "$line $extra_info"
     done < <(virsh "list --all")

--- a/guest-tools/tdvirsh
+++ b/guest-tools/tdvirsh
@@ -173,7 +173,7 @@ print_all() {
                     awk '/guest-cid/ {print $3}'
                      )
             host_ip=$(
-               virsh domifaddr ${td_domain}  |
+               virsh domifaddr ${td_domain} 2>&1 |
                     awk '/vnet/ {print $4}'
                      )
             extra_info="(ip:${host_ip}, ssh:$host_port, cid:${guest_cid})"

--- a/guest-tools/trust_domain-sb.xml.template
+++ b/guest-tools/trust_domain-sb.xml.template
@@ -40,6 +40,11 @@
       </backingStore>
       <target dev="vda" bus="virtio"/>
     </disk>
+    <interface type='network'>
+      <source network='default'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
+    </interface>
     <console type='pty'>
       <target type='virtio' port='1'/>
     </console>

--- a/guest-tools/trust_domain.xml.template
+++ b/guest-tools/trust_domain.xml.template
@@ -40,6 +40,11 @@
       </backingStore>
       <target dev="vda" bus="virtio"/>
     </disk>
+    <interface type='network'>
+      <source network='default'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
+    </interface>
     <console type='pty'>
       <target type='virtio' port='1'/>
     </console>


### PR DESCRIPTION
This work has been motivated by the demo we were trying to do for Confidential RAG where we will need multiple TD VMs to communicate between them.

With this change, the guest will be accessible via it own IP:

```shell
ssh root@<IP>
```

instead of 

```shell
ssh -p <forward-port> root@localhost
```

And `tdvirsh list` will also print the guest IP:

```
$ ./tdvirsh list
Id   Name                                                        State 
--------------------------------------------------------------------------- 
2    tdvirsh-trust_domain-508f629e-4e86-4969-8517-da1ba35258ed   running (ip:192.168.122.212, hostfwd:44321, cid:3)
```