### PR TITLE
fix failing tests cause of permanent modification of qemu machine arguments

### DIFF
--- a/tests/tests/test_quote_configfs_tsm.py
+++ b/tests/tests/test_quote_configfs_tsm.py
@@ -41,8 +41,8 @@ def test_qgs_socket(qm):
     """
     Test QGS socket (No Intel Case ID)
     """
-    object = '{"qom-type":"tdx-guest","id":"tdx","quote-generation-socket":{"type": "vsock", "cid":"2","port":"4050"}}'
-    Qemu.QemuMachineType.Qemu_Machine_Params[Qemu.QemuEfiMachine.OVMF_Q35_TDX][1] = object
+    machine = qm.qcmd.plugins['machine']
+    machine.enable_quote_socket()
 
     qm.run()
 


### PR DESCRIPTION
currently in the test tests/test_quote_configfs_tsm.py::test_qgs_socket we modify permanently the qemu -machine and -object arguments. this can make following tests fail

we do not want to modify these arguments permanently but only for the current test