### PR TITLE
tests: add test to check tdx flag in CPU info

### DIFF
--- a/tests/lib/tdx-tools/src/tdxtools/host.py
+++ b/tests/lib/tdx-tools/src/tdxtools/host.py
@@ -25,7 +25,7 @@ def support_tdx():
     """
     Check whether support TDX in CPU info
     """
-    return 'tdx' in cpuinfo.get_cpu_info()['flags']
+    return 'tdx_host_platform' in cpuinfo.get_cpu_info()['flags']
 
 
 def support_sgx():

--- a/tests/tests/test_host_tdx_software.py
+++ b/tests/tests/test_host_tdx_software.py
@@ -19,6 +19,14 @@
 
 import re
 import subprocess
+import tdxtools
+
+def test_host_tdx_cpu():
+    """
+    Check that the CPU has TDX support enabled
+    (the flag tdx_host_platform is present)
+    """
+    assert tdxtools.host.support_tdx()
 
 def test_host_tdx_software():
 


### PR DESCRIPTION
On host system that supports TDX, the CPU info (`lscpu` or `/proc/cpuinfo`) should have the flag `tdx_host_platform`