### PR TITLE
fix failing test vsock in checkbox provider

### DIFF
--- a/tests/checkbox/checkbox-provider-tdx/units/tests/jobs.pxu
+++ b/tests/checkbox/checkbox-provider-tdx/units/tests/jobs.pxu
@@ -235,8 +235,18 @@ depends:
 after:
 requires:
   executable.name == 'qemu-system-x86_64'
+  executable.name == 'iperf3'
 command:
   export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+  # The order of binary look-up:
+  #  - test working folder
+  #  - checkbox
+  #  - provider
+  #  - snaps binaries (/snap/bin)
+  #  - host system
+  # so for iperf3, the binary from the checkbox snap will be used.
+  # however we want to use the one from tdx provider (that has vsock support)
+  export PATH=${SNAP}/usr/bin/:${PATH}
   setup-env-and-run test_vsock_vm.py
 
 id: tdx-guest/td-memory

--- a/tests/snap/snapcraft.yaml
+++ b/tests/snap/snapcraft.yaml
@@ -74,6 +74,10 @@ passthrough:
     configure:
       command-chain: [bin/wrapper_local]
 
+package-repositories:
+ - type: apt
+   ppa: kobuk-team/testing
+
 parts:
   checkbox-provider-tdx:
     plugin: dump
@@ -88,6 +92,7 @@ parts:
       - python3-pytest
       - sshpass
       - cpuid
+      - iperf-vsock
     override-build: |
       # the validation tool needs to access the to all checkbox providers
       # we have to set the PROVIDERPATH to point to them


### PR DESCRIPTION
vsock test uses a customized iperf tool with vsock support
this tool is installed on the host

however, checkbox24 comes with iperf tool and it will be used by the test,
without vsock support, the test fails

we device to bundle the customized iperf tool to the checkbox provider
and set PATH variable to use the iperf in the provider

one other solution would be to set the PATH to use the iperf installed on the system
but we think that bundle iperf3 into the provider is a better approach