### PR TITLE
add test to check quote generation via vsock

### DIFF
--- a/tests/lib/Qemu.py
+++ b/tests/lib/Qemu.py
@@ -169,15 +169,21 @@ class QemuMachineType:
     }
     def __init__(self, machine = QemuEfiMachine.OVMF_Q35_TDX):
         self.machine = machine
-        self.quote_sock = False
-    def enable_quote_socket(self):
-        self.quote_sock = True
+        self.qgs_addr = None
+    def enable_qgs_addr(self, addr : dict = {'type': 'vsock', 'cid':'2','port':'4050'}):
+        """
+        Enable the QGS (Quote Generation Service) address
+        The address is a dictionary that corresponds to the object
+        (https://qemu-project.gitlab.io/qemu/interop/qemu-qmp-ref.html#qapidoc-77)
+        By default, the address is a vsock address with cid=2 (host cid) and port=4050
+        """
+        self.qgs_addr = addr
     def args(self):
         qemu_args = self.Qemu_Machine_Params[self.machine]
         if self.machine == QemuEfiMachine.OVMF_Q35_TDX:
             tdx_object = {'qom-type':'tdx-guest', 'id':'tdx'}
-            if self.quote_sock:
-                tdx_object.update({'quote-generation-socket':{'type': 'vsock', 'cid':'2','port':'4050'}})
+            if self.qgs_addr:
+                tdx_object.update({'quote-generation-socket': self.qgs_addr})
             qemu_args = ['-object', str(tdx_object)] + qemu_args
         return qemu_args
 

--- a/tests/tests/test_guest_ita.py
+++ b/tests/tests/test_guest_ita.py
@@ -55,7 +55,7 @@ def run_trust_authority():
     quote_str = ""
     with Qemu.QemuMachine() as qm:
         machine = qm.qcmd.plugins['machine']
-        machine.enable_quote_socket()
+        machine.enable_qgs_addr()
 
         qm.run()
 

--- a/tests/tests/test_quote_configfs_tsm.py
+++ b/tests/tests/test_quote_configfs_tsm.py
@@ -42,7 +42,7 @@ def test_qgs_socket(qm):
     Test QGS socket (No Intel Case ID)
     """
     machine = qm.qcmd.plugins['machine']
-    machine.enable_quote_socket()
+    machine.enable_qgs_addr()
 
     qm.run()
 

--- a/tests/tests/test_stress_quote.py
+++ b/tests/tests/test_stress_quote.py
@@ -24,7 +24,7 @@ def test_stress_tdxattest_tsm():
     """
     with Qemu.QemuMachine() as qm:
         machine = qm.qcmd.plugins['machine']
-        machine.enable_quote_socket()
+        machine.enable_qgs_addr()
 
         qm.run()
         ssh = Qemu.QemuSSH(qm)


### PR DESCRIPTION
this test will contribute to verify the issue #252 

the test that checks the issue is `tests/test_guest_tdxattest.py::test_guest_tdxattest_vsock_wrong_qgs_addr`
it currently fails and should succeed once the issue is resolved

```
QemuMachine created.
qemu-system-x86_64 -cpu host -smp 16,sockets=1 -accel kvm -nographic -nodefaults -no-user-config -m 2G -bios /usr/share/ovmf/OVMF.fd -object {'qom-type': 'tdx-guest', 'id': 'tdx', 'quote-generation-socket': {'type': 'vsock', 'cid': '3', 'port': '4050'}} -machine q35,kernel_irqchip=split,confidential-guest-support=tdx -drive file=/tmp/tdxtest-default-xc64ol1d/image.qcow2,if=none,id=virtio-disk0 -device virtio-blk-pci,drive=virtio-disk0 -pidfile /tmp/tdxtest-default-xc64ol1d/qemu.pid -monitor unix:/tmp/tdxtest-default-xc64ol1d/monitor.sock,server,nowait -qmp unix:/tmp/tdxtest-default-xc64ol1d/qmp.sock,server=on,wait=off -device virtio-net-pci,netdev=nic0_td -netdev user,id=nic0_td,hostfwd=tcp::55375-:22 -D /tmp/tdxtest-default-xc64ol1d/qemu-log.txt -chardev file,id=c1,path=/tmp/tdxtest-default-xc64ol1d/serial.log,signal=off -device isa-serial,chardev=c1 -device vhost-vsock-pci,guest-cid=10
Connecting ...
Connected ...

Failed to get the quote

FAILED

```
additional changes:
 - enable the function enable_quote_socket to enable_qgs_addr to better match what it does, add an argument to allow the customization of the QGS address

