### PR TITLE
Display login information of non-root user in addition to root user

### DIFF
--- a/guest-tools/run_td.sh
+++ b/guest-tools/run_td.sh
@@ -72,4 +72,8 @@ fi
 
 PID_TD=$(cat /tmp/tdx-demo-td-pid.pid)
 
-echo "TD, PID: ${PID_TD}, SSH : ssh -p 10022 root@localhost"
+echo "TD, PID: ${PID_TD},
+To login with a non-root user, specified during the creation of
+image, use SSH : ssh -p 10022 <username>@localhost
+The default non-root user is tdx
+To login as a root, use SSH : ssh -p 10022 root@localhost"

--- a/guest-tools/run_td.sh
+++ b/guest-tools/run_td.sh
@@ -73,7 +73,7 @@ fi
 PID_TD=$(cat /tmp/tdx-demo-td-pid.pid)
 
 echo "TD, PID: ${PID_TD},
-To login with a non-root user, specified during the creation of
+To login with a non-root user, specified during the creation of the
 image, use SSH : ssh -p 10022 <username>@localhost
-The default non-root user is tdx
+The default non-root user is `tdx`
 To login as a root, use SSH : ssh -p 10022 root@localhost"


### PR DESCRIPTION
### Description of the changes
Currently, `run_td.sh `shows `ssh `command only for root user.
It does not show TD login information for the default user.
It also does not show TD login information for customized TD guest user(specified during TD image creation)

### How to test this PR?
1. Please follow the instructions given [here](https://github.com/canonical/tdx/tree/noble-24.04?tab=readme-ov-file#51-create-a-new-td-image) to create a TD image.
2. Follow the instructions given [here](https://github.com/canonical/tdx/tree/noble-24.04?tab=readme-ov-file#61-boot-td-with-qemu) to boot the TD with qemu.
3. TD login information with `ssh`commands will be displayed
