### PR TITLE
tests : move packages used by TDX test to tdx-testing

### DIFF
--- a/tests/lib/setup_guest.sh
+++ b/tests/lib/setup_guest.sh
@@ -9,6 +9,6 @@ DEBIAN_FRONTEND=noninteractive apt install -y python3 python3-pip
 cd ${SCRIPT_DIR}/tdx-tools/
 python3 -m pip install --break-system-packages ./
 sudo apt remove iperf3 -y
-sudo add-apt-repository ppa:kobuk-team/testing -y
+sudo add-apt-repository ppa:kobuk-team/tdx-testing -y
 sudo apt update
 sudo apt install iperf-vsock -y

--- a/tests/snap/snapcraft.yaml
+++ b/tests/snap/snapcraft.yaml
@@ -76,7 +76,7 @@ passthrough:
 
 package-repositories:
  - type: apt
-   ppa: kobuk-team/testing
+   ppa: kobuk-team/tdx-testing
 
 parts:
   checkbox-provider-tdx:

--- a/tests/tox/setup-env-tox.sh
+++ b/tests/tox/setup-env-tox.sh
@@ -38,7 +38,7 @@ cleanup() {
 install_deps() {
   sudo apt install -y sshpass cpuid
   sudo apt remove iperf3 -y
-  sudo add-apt-repository ppa:kobuk-team/testing -y
+  sudo add-apt-repository ppa:kobuk-team/tdx-testing -y
   sudo apt update || true
   sudo apt install iperf-vsock -y
 }


### PR DESCRIPTION
until now, the packages (vsock-iperf) are uploaded in the testing PPA this testing PPA is a temporary PPA used for various debugging purposes and can be removed at any time, we created a new PPA dedicated to host test packages for TDX (tdx-testing)

this patch make the TDX tests use this new PPA