### PR TITLE
Noble 24.04 minor improvements

### DIFF
--- a/tests/lib/Qemu.py
+++ b/tests/lib/Qemu.py
@@ -27,6 +27,7 @@ import subprocess
 import tempfile
 import time
 import sys
+import stat
 
 import util
 
@@ -72,6 +73,17 @@ class QemuGraphic():
         if self.nographic == True:
             return ['-nographic']
         return []
+
+class QemuSerial():
+    def __init__(self, serial_file : str = None):
+        self.serial_file = serial_file
+    def args(self):
+        if self.serial_file:
+            return [
+                '-chardev', f'file,id=c1,path={self.serial_file},signal=off',
+                '-device', 'isa-serial,chardev=c1'
+            ]
+        return ['-serial', 'stdio']
 
 class QemuUserConfig:
     def __init__(self):
@@ -229,6 +241,7 @@ class QemuCommand:
                         'config': QemuUserConfig(),
                         'memory': QemuMemory(memory),
                         'ovmf' : QemuOvmf(machine),
+                        'serial' : QemuSerial(f'{self.workdir}/serial.log'),
                         'machine' : QemuMachineType(machine)}
         self.command = ['-pidfile', f'{self.workdir}/qemu.pid']
 
@@ -237,13 +250,6 @@ class QemuCommand:
         for p in self.plugins.values():
             _args.extend(p.args())
         return _args + self.command
-
-    def add_serial_to_file(self):
-        # serial to file
-        self.command = self.command + [
-            '-chardev', f'file,id=c1,path={self.workdir}/serial.log,signal=off',
-            '-device', 'isa-serial,chardev=c1'
-        ]
 
     def add_qemu_run_log(self):
         # serial to file
@@ -467,6 +473,15 @@ class QemuMachineService:
     QEMU_MACHINE_MONITOR = enum.auto()
     QEMU_MACHINE_QMP = enum.auto()
 
+# run script to run the guest
+# this is used for debugging purpose and allow users
+# to run the guest manually
+qemu_run_script = """
+#!/bin/bash
+echo "To connect to the VM : ssh -p {fwd_port} root@localhost"
+{cmd_str}
+"""
+ 
 class QemuMachine:
     debug_enabled = False
     # hold all qemu instances
@@ -498,7 +513,6 @@ class QemuMachine:
             self.fwd_port = util.tcp_port_available()
             self.qcmd.add_port_forward(self.fwd_port)
         self.qcmd.add_qemu_run_log()
-        self.qcmd.add_serial_to_file()
 
         self.proc = None
         self.out = None
@@ -572,6 +586,8 @@ class QemuMachine:
         """
         cmd = self.qcmd.get_command()
         print(' '.join(cmd))
+        script=f'{self.workdir_name}/run.sh'
+        self.write_cmd_to_file(script)
         self.proc = subprocess.Popen(cmd,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
@@ -580,11 +596,7 @@ class QemuMachine:
         """
         Run qemu and wait for its start (by waiting for monitor file's availability)
         """
-        cmd = self.qcmd.get_command()
-        print(' '.join(cmd))
-        self.proc = subprocess.Popen(cmd,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+        self.run()
         QemuMonitor(self)
 
     def communicate(self):
@@ -622,6 +634,33 @@ class QemuMachine:
         self.communicate()
         # run the VM again
         self.run()
+
+    def write_cmd_to_file(self, fname : str):
+        """
+        Write the qemu command to a executable bash script
+        """
+        # force -serial to stdio to be able to have the console on stdio
+        cur_serial = self.qcmd.plugins['serial']
+        self.qcmd.plugins['serial'] = QemuSerial()
+
+        cmd = self.qcmd.get_command()
+        with open(fname, 'w+') as run_script:
+            cmd_str=''
+            for el in cmd:
+                # escape qemu object with quotes
+                # for example : -object "{'qom-type': 'tdx-guest', 'id': 'tdx'}"
+                if el.startswith('{') and el.endswith('}'):
+                    cmd_str += f'\"{el}\" '
+                else:
+                    cmd_str += f'{el} '
+                script_contents = qemu_run_script.format(fwd_port=self.fwd_port,
+                                                         cmd_str=cmd_str)
+            run_script.write(script_contents)
+        f = pathlib.Path(fname)
+        f.chmod(f.stat().st_mode | stat.S_IEXEC)
+
+        # restore serial config
+        self.qcmd.plugins['serial'] = cur_serial
 
     def __del__(self):
         """


### PR DESCRIPTION
This PR comes with 2 commits:

- output the qemu command to a script
this will allow users to run manually the guest after the test
this capability is useful for debugging purposes
for example, the user can run the guest manually by doing:
```bash
$ sudo /tmp/tdxtest-default-hk8u6mf3/run.sh
```
`hk8u6mf3` is random and may vary for each test

- right now, we use `proc.terminate()` to send SIGTERM to qemu process
this tends to corrupt the rootfs
this will prevent us from running the guest again with this rootfs
try to stop the VM (shutdown) properly first and terminate() it
later if necessary
