### PR TITLE
Update README.md to remove confusion about API Key in Intel Tiber Tru…

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ you proceed to [step 4](#verify-itts-client-version).
 
 3. Attest with the [Intel Tiber Trust Service](https://www.intel.com/content/www/us/en/security/trust-authority.html).
    1. Subscribe to the Intel Tiber Trust Service [free trial](https://plan.seek.intel.com/2023_ITATrialForm).
-   2. Obtain an API key following this [tutorial](https://docs.trustauthority.intel.com/main/articles/tutorial-api-key.html?tabs=attestation-api-key-portal%2Cattestation-sgx-client).
+   2. Obtain an Attestation API key following this [tutorial](https://docs.trustauthority.intel.com/main/articles/tutorial-api-key.html?tabs=attestation-api-key-portal%2Cattestation-sgx-client).
 
    3. Create a `config.json` file like the example below:
 
@@ -542,7 +542,7 @@ you proceed to [step 4](#verify-itts-client-version).
 		{
 			"trustauthority_url": "https://portal.trustauthority.intel.com",
 			"trustauthority_api_url": "https://api.trustauthority.intel.com",
-			"trustauthority_api_key": "<Your Intel Tiber Trust Service API key>"
+			"trustauthority_api_key": "<Your Intel Tiber Trust Service Attestation API key>"
 		}
 		```
 


### PR DESCRIPTION
…st Services

This commit is made to clearly specify that the API Key in Step 9 is Attestation API Key, so that someone doesn't continue with Admin API Key which comes ahead in the tutorial provided. Making this correction from personal experience [Issue#144](https://github.com/canonical/tdx/issues/144).

