### PR TITLE
several improvements for tests in Ubuntu 24.10

### DIFF
--- a/tests/lib/Qemu.py
+++ b/tests/lib/Qemu.py
@@ -481,7 +481,6 @@ class QemuMachineService:
 # to run the guest manually
 qemu_run_script = """
 #!/bin/bash
-echo "To connect to the VM : ssh -p {fwd_port} root@localhost"
 {cmd_str}
 """
  
@@ -606,7 +605,7 @@ class QemuMachine:
         """
         Wait for qemu to exit
         """
-        self.out, self.err = self.proc.communicate()
+        self.out, self.err = self.proc.communicate(timeout=60)
         if self.proc.returncode != 0:
             print(self.err.decode())
         return self.out, self.err
@@ -632,7 +631,7 @@ class QemuMachine:
         except Exception as e:
             pass
 
-        print('Qemu process did not shutdown properly, terminate it ...')
+        print(f'Qemu process did not shutdown properly, terminate it ... ({self.workdir_name})')
         # terminate qemu process (SIGTERM)
         try:
             self.proc.terminate()
@@ -671,8 +670,7 @@ class QemuMachine:
                     cmd_str += f'\"{el}\" '
                 else:
                     cmd_str += f'{el} '
-                script_contents = qemu_run_script.format(fwd_port=self.fwd_port,
-                                                         cmd_str=cmd_str)
+                script_contents = qemu_run_script.format(cmd_str=cmd_str)
             run_script.write(script_contents)
         f = pathlib.Path(fname)
         f.chmod(f.stat().st_mode | stat.S_IEXEC)

--- a/tests/lib/Qemu.py
+++ b/tests/lib/Qemu.py
@@ -318,10 +318,10 @@ class QemuMonitor():
                 break
             except Exception as e:
                 # give some time to make sure socket file is available
-                print(f'Try to connect to qemu : {qemu.qcmd.monitor_file} : {e}')
                 time.sleep(1)
         self.socket.settimeout(self.READ_TIMEOUT)
         # wait for promt
+        print(f'Connected : {qemu.qcmd.monitor_file}, wait for prompt.')
         self.wait_prompt()
 
     def recv_data(self):
@@ -649,11 +649,13 @@ class QemuMachine:
 
         # self.proc.returncode == None -> not yet terminated
 
-        # try to shutdown the VM properly, this is important to avoid
-        # rootfs corruption if we want to run the guest again
-        mon = QemuMonitor(self)
-        mon.powerdown()
         try:
+            # try to shutdown the VM properly, this is important to avoid
+            # rootfs corruption if we want to run the guest again
+            # catch exception and ignore it since we are stopping .... no need to fail the test
+            mon = QemuMonitor(self)
+            mon.powerdown()
+
             self.communicate()
             return
         except Exception as e:

--- a/tests/lib/Qemu.py
+++ b/tests/lib/Qemu.py
@@ -320,7 +320,7 @@ class QemuMonitor():
                 # give some time to make sure socket file is available
                 time.sleep(1)
         self.socket.settimeout(self.READ_TIMEOUT)
-        # wait for promt
+        # wait for prompt
         print(f'Connected : {qemu.qcmd.monitor_file}, wait for prompt.')
         self.wait_prompt()
 

--- a/tests/tests/test_stress_boot.py
+++ b/tests/tests/test_stress_boot.py
@@ -22,7 +22,7 @@ import Qemu
 
 import util
 
-def test_boot():
+def test_stress_boot():
     """
     Boot in loop
     """

--- a/tests/tests/test_stress_resources.py
+++ b/tests/tests/test_stress_resources.py
@@ -34,7 +34,8 @@ def test_stress_huge_resource_vm(qm):
     qm.qcmd.plugins['memory'].memory = '%dG' % (huge_mem_gb)
     qm.run()
 
-    ssh = Qemu.QemuSSH(qm)
+    # huge guest memory -> increase the timeout to give more time to guest to boot
+    ssh = Qemu.QemuSSH(qm, timeout=100)
 
     qm.stop()
 
@@ -65,7 +66,7 @@ def test_stress_max_vcpus(qm):
     qm.qcmd.plugins['cpu'].nb_cores = num_cpus
     qm.run()
 
-    ssh = Qemu.QemuSSH(qm)
+    ssh = Qemu.QemuSSH(qm, timeout=100)
 
     qm.stop()
 

--- a/tests/tests/test_stress_resources.py
+++ b/tests/tests/test_stress_resources.py
@@ -21,7 +21,7 @@ import multiprocessing
 import Qemu
 import util
 
-def test_huge_resource_vm(qm):
+def test_stress_huge_resource_vm(qm):
     """
     Test huge resources  (Intel Case ID 007)
     """
@@ -38,7 +38,7 @@ def test_huge_resource_vm(qm):
 
     qm.stop()
 
-def test_memory_limit_resource_vm(qm):
+def test_stress_memory_limit_resource_vm(qm):
     """
     Test memory limit resource  (No Intel Case)
     """
@@ -54,7 +54,7 @@ def test_memory_limit_resource_vm(qm):
     qm.stop()
 
 
-def test_max_vcpus(qm):
+def test_stress_max_vcpus(qm):
     """
     Test max vcpus (No Intel Case ID)
     """
@@ -70,7 +70,7 @@ def test_max_vcpus(qm):
     qm.stop()
 
 
-def test_max_guests():
+def test_stress_max_guests():
     """
     Test max guests (No Intel Case ID)
     """

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -46,6 +46,10 @@ commands =
 commands = 
   python3 -m pytest -s -v --junitxml=test_stress_report.xml -k test_stress
 
+[testenv:test_all_except_perf]
+commands =
+  python3 -m pytest -s -v --junitxml=test_all_report.xml -k 'not test_perf'
+
 [testenv:test_all]
 commands = 
   python3 -m pytest -s -v --junitxml=test_all_report.xml

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -24,40 +24,40 @@ commands_pre =
 
 [testenv:test_guest]
 commands = 
-  python3 -m pytest -s -v --junitxml=test_guest_report.xml -k test_guest
+  python3 -m pytest -s -v --junitxml=test_guest_report.xml --ignore=tests/guest -k test_guest
 
 [testenv:test_host]
 commands = 
-  python3 -m pytest -s -v --junitxml=test_host_report.xml -k test_host
+  python3 -m pytest -s -v --junitxml=test_host_report.xml --ignore=tests/guest -k test_host
 
 [testenv:test_boot]
 commands = 
-  python3 -m pytest -s -v --junitxml=test_boot_report.xml -k test_boot
+  python3 -m pytest -s -v --junitxml=test_boot_report.xml --ignore=tests/guest -k test_boot
 
 [testenv:test_perf]
 commands = 
-  python3 -m pytest -s -v --junitxml=test_perf_report.xml -k test_perf
+  python3 -m pytest -s -v --junitxml=test_perf_report.xml --ignore=tests/guest -k test_perf
 
 [testenv:test_quote]
 commands = 
-  python3 -m pytest -s -v --junitxml=test_quote_report.xml -k test_quote
+  python3 -m pytest -s -v --junitxml=test_quote_report.xml --ignore=tests/guest -k test_quote
 
 [testenv:test_stress]
 commands = 
-  python3 -m pytest -s -v --junitxml=test_stress_report.xml -k test_stress
+  python3 -m pytest -s -v --junitxml=test_stress_report.xml --ignore=tests/guest -k test_stress
 
 [testenv:test_all_except_perf]
 commands =
-  python3 -m pytest -s -v --junitxml=test_all_report.xml -k 'not test_perf'
+  python3 -m pytest -s -v --junitxml=test_all_report.xml --ignore=tests/guest -k 'not test_perf'
 
 [testenv:test_all]
 commands = 
-  python3 -m pytest -s -v --junitxml=test_all_report.xml
+  python3 -m pytest -s -v --junitxml=test_all_report.xml --ignore=tests/guest
 
 [testenv:test_specify]
 commands = 
-  python3 -m pytest -s -v --junitxml=test_specify_report.xml -k {posargs}
+  python3 -m pytest -s -v --junitxml=test_specify_report.xml --ignore=tests/guest -k {posargs}
 
 [testenv:collect_tests]
 commands =
-  python3 -m pytest -s -v --collect-only -k {posargs}
+  python3 -m pytest -s -v --collect-only --ignore=tests/guest -k {posargs}


### PR DESCRIPTION
This MR comes as several commits, please check them out separately to have more context of all the changes.

The changes are:

- renaming of some test functions to be aligned with test file name
- increase ssh connection timeout for some stress tests since the guests can take more time to boot
- tox : add command to run all tests except performance ones
- does not make the test fail if we cannot stop the guest properly via monitor interface since for some tests, the guest may 
   be shutdown already, etc ...
- for an unknown reason, we can not have multiple connections to the qemu process monitor interface via unix sock file
  only one connection is possible, others are blocked.
  for this reason, we will allow only one instance of monitor connection for each qemu process