### PR TITLE
Add correction to echo command in run_td.sh

### DIFF
--- a/guest-tools/run_td.sh
+++ b/guest-tools/run_td.sh
@@ -75,5 +75,5 @@ PID_TD=$(cat /tmp/tdx-demo-td-pid.pid)
 echo "TD, PID: ${PID_TD},
 To login with a non-root user, specified during the creation of the
 image, use SSH : ssh -p 10022 <username>@localhost
-The default non-root user is `tdx`
+The default non-root user is tdx
 To login as a root, use SSH : ssh -p 10022 root@localhost"


### PR DESCRIPTION
The echo command in `run_td.sh` has `tdx` (with backticks) in the below line [line no.78]
 `The default non-root user is <backtick>tdx<backtick>`
Because of the backticks, when its printed on shell, it takes `tdx` as a command.
Hence, errors out displaying:
_tdx: command not found_

Adding this change to remove the backticks.