### PR TITLE
add the management of multiple ubuntu releases

### DIFF
--- a/guest-tools/image/cloud-init-data/user-data
+++ b/guest-tools/image/cloud-init-data/user-data
@@ -14,7 +14,7 @@ write_files:
   path: /etc/netplan/netplan.yaml
 - content: |
     ===========================================================================
-    Welcome to Ubuntu noble (24.04)
+    Welcome to Ubuntu
     Created by Kobuk team
     ===========================================================================
   path: /etc/motd

--- a/guest-tools/image/cloud-init-data/user-data.template
+++ b/guest-tools/image/cloud-init-data/user-data.template
@@ -14,7 +14,7 @@ write_files:
   path: /etc/netplan/netplan.yaml
 - content: |
     ===========================================================================
-    Welcome to Ubuntu noble (24.04)
+    Welcome to Ubuntu
     Created by Kobuk team
     ===========================================================================
   path: /etc/motd

--- a/guest-tools/image/create-td-image.sh
+++ b/guest-tools/image/create-td-image.sh
@@ -43,13 +43,15 @@ fi
 
 LOGFILE=/tmp/tdx-guest-setup.txt
 FORCE_RECREATE=false
-OFFICIAL_UBUNTU_IMAGE=${OFFICIAL_UBUNTU_IMAGE:-"https://cloud-images.ubuntu.com/releases/noble/release/"}
-CLOUD_IMG=${CLOUD_IMG:-"ubuntu-24.04-server-cloudimg-amd64.img"}
+CODE_NAME=$(lsb_release -cs)
+UBUNTU_VERSION=$(lsb_release -rs)
+OFFICIAL_UBUNTU_IMAGE=${OFFICIAL_UBUNTU_IMAGE:-"https://cloud-images.ubuntu.com/releases/${CODE_NAME}/release/"}
+CLOUD_IMG=${CLOUD_IMG:-"ubuntu-${UBUNTU_VERSION}-server-cloudimg-amd64.img"}
 CLOUD_IMG_PATH=$(realpath "${SCRIPT_DIR}/${CLOUD_IMG}")
 if [[ "${TDX_SETUP_INTEL_KERNEL}" == "1" ]]; then
-    GUEST_IMG_PATH=$(realpath "tdx-guest-ubuntu-24.04-intel.qcow2")
+    GUEST_IMG_PATH=$(realpath "tdx-guest-ubuntu-${UBUNTU_VERSION}-intel.qcow2")
 else
-    GUEST_IMG_PATH=$(realpath "tdx-guest-ubuntu-24.04-generic.qcow2")
+    GUEST_IMG_PATH=$(realpath "tdx-guest-ubuntu-${UBUNTU_VERSION}-generic.qcow2")
 fi
 TMP_GUEST_IMG_PATH="/tmp/tdx-guest-tmp.qcow2"
 SIZE=50
@@ -88,7 +90,7 @@ Usage: $(basename "$0") [OPTION]...
   -u                        Guest user name, default is "tdx"
   -p                        Guest password, default is "123456"
   -s                        Specify the size of guest image
-  -o <output file>          Specify the output file, default is tdx-guest-ubuntu-24.04.qcow2.
+  -o <output file>          Specify the output file, default is tdx-guest-ubuntu-${UBUNTU_VERSION}.qcow2.
                             Please make sure the suffix is qcow2. Due to permission consideration,
                             the output file will be put into /tmp/<output file>.
 EOM
@@ -224,7 +226,7 @@ apply_cloud_init_conf() {
   virt-install --debug --memory 4096 --vcpus 4 --name tdx-config-cloud-init \
      --disk ${TMP_GUEST_IMG_PATH} \
      --disk /tmp/ciiso.iso,device=cdrom \
-     --os-variant ubuntu24.04 \
+     --os-variant ubuntu${UBUNTU_VERSION} \
      --virt-type ${virt_type} \
      --graphics none \
      --import \

--- a/guest-tools/run_td.sh
+++ b/guest-tools/run_td.sh
@@ -32,7 +32,8 @@ if [ "$1" = "clean" ]; then
     exit 0
 fi
 
-TD_IMG=${TD_IMG:-${PWD}/image/tdx-guest-ubuntu-24.04-generic.qcow2}
+UBUNTU_VERSION=$(lsb_release -rs)
+TD_IMG=${TD_IMG:-${PWD}/image/tdx-guest-ubuntu-${UBUNTU_VERSION}-generic.qcow2}
 TDVF_FIRMWARE=/usr/share/ovmf/OVMF.fd
 
 if ! groups | grep -qw "kvm"; then

--- a/guest-tools/tdvirsh
+++ b/guest-tools/tdvirsh
@@ -25,10 +25,10 @@
 DOMAIN_PREFIX="tdvirsh"
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 SCRIPT_NAME=$(basename "$0")
-BASE_IMG_DEFAULT=${SCRIPT_DIR}/image/tdx-guest-ubuntu-24.04-generic.qcow2
+UBUNTU_VERSION=$(lsb_release -rs)
+BASE_IMG_DEFAULT=${SCRIPT_DIR}/image/tdx-guest-ubuntu-${UBUNTU_VERSION}-generic.qcow2
 XML_TEMPLATE_DEFAULT=${SCRIPT_DIR}/trust_domain.xml.template
 WORKDIR_PATH=/var/tmp/tdvirsh/
-
 
 ##
 # Global variables
@@ -48,7 +48,7 @@ Available options:
 
 new [--td-image|-i PATH] [--xml-template|-t PATH]
                             Run a Trust Domain (TD)
-                                Default TD image path: ./image/tdx-guest-ubuntu-24.04-generic.qcow2
+                                Default TD image path: ./image/tdx-guest-ubuntu-${UBUNTU_VERSION}-generic.qcow2
                                 Default XML template path: ./trust_domain.xml.template
 delete <domain|all>         Stop and delete Trust Domain (TD)
                                <domain> should be a valid domain name

--- a/setup-tdx-common
+++ b/setup-tdx-common
@@ -28,7 +28,6 @@
 add_kobuk_ppa() {
   ppa_id=$1
   distro_id=LP-PPA-kobuk-team-${ppa_id}
-  distro_codename=noble
 
   add-apt-repository -y ppa:kobuk-team/${ppa_id}
 
@@ -40,7 +39,7 @@ EOF
 
   cat <<EOF | tee /etc/apt/apt.conf.d/99unattended-upgrades-kobuk-${ppa_id}
 Unattended-Upgrade::Allowed-Origins {
-  "${distro_id}:${distro_codename}";
+  "${distro_id}:${UBUNTU_CODENAME}";
 };
 Unattended-Upgrade::Allow-downgrade "true";
 EOF

--- a/setup-tdx-common
+++ b/setup-tdx-common
@@ -14,6 +14,12 @@
 # of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
 # See the GNU General Public License for more details.
 
+# If not set, detect Ubuntu code name and version
+if [[ -z "${UBUNTU_CODENAME}" ]] || [[ -z "${UBUNTU_VERSION}" ]]; then
+  UBUNTU_CODENAME=$(lsb_release -cs)
+  UBUNTU_VERSION=$(lsb_release -rs)
+fi
+
 # Pinning the packages of specific PPA
 #
 # unattended-upgrade:

--- a/setup-tdx-config
+++ b/setup-tdx-config
@@ -18,6 +18,9 @@
 # GENERAL                                                      #
 ################################################################
 
+UBUNTU_CODENAME=$(lsb_release -cs)
+UBUNTU_VERSION=$(lsb_release -rs)
+
 ################################################################
 # The TDX PPAs to use
 # By default, there is only the release PPA : tdx-release
@@ -58,12 +61,12 @@ TDX_SETUP_INTEL_KERNEL=0
 
 ################################################################
 # Image configuration
-# The base image is an Ubuntu 24.04 cloud image
+# The base image is an Ubuntu cloud image
 # You can use a different image setting these two environment
 # variables before running the setup script
 ################################################################
-OFFICIAL_UBUNTU_IMAGE="https://cloud-images.ubuntu.com/releases/noble/release/"
-CLOUD_IMG="ubuntu-24.04-server-cloudimg-amd64.img"
+OFFICIAL_UBUNTU_IMAGE="https://cloud-images.ubuntu.com/releases/${UBUNTU_CODENAME}/release/"
+CLOUD_IMG="ubuntu-${UBUNTU_VERSION}-server-cloudimg-amd64.img"
 
 ################################################################
 # Configure the guest credentials

--- a/setup-tdx-config
+++ b/setup-tdx-config
@@ -18,9 +18,6 @@
 # GENERAL                                                      #
 ################################################################
 
-UBUNTU_CODENAME=$(lsb_release -cs)
-UBUNTU_VERSION=$(lsb_release -rs)
-
 ################################################################
 # The TDX PPAs to use
 # By default, there is only the release PPA : tdx-release


### PR DESCRIPTION
for now, this branch only supports 24.04, with the upcoming 24.10 support, we would like this branch to offer it instead of using a different branch

this helps us to lower the maintenance effort since the majority of the code base is release agnostic. (especially tests, tools, documentation ....)