### PR TITLE
libvirt : set ovmf readonly flag to true

### DIFF
--- a/guest-tools/regular_vm.xml.template
+++ b/guest-tools/regular_vm.xml.template
@@ -4,7 +4,7 @@
   <vcpu placement="static">16</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
-    <loader>/usr/share/qemu/OVMF.fd</loader>
+    <loader type='rom' readonly='yes'>/usr/share/qemu/OVMF.fd</loader>
     <boot dev='hd'/>
   </os>
   <features>

--- a/guest-tools/trust_domain-sb.xml.template
+++ b/guest-tools/trust_domain-sb.xml.template
@@ -8,7 +8,7 @@
   <vcpu placement="static">16</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
-    <loader>/usr/share/ovmf/OVMF.tdx.fd</loader>
+    <loader type='rom' readonly='yes'>/usr/share/ovmf/OVMF.tdx.fd</loader>
     <boot dev='hd'/>
   </os>
   <features>

--- a/guest-tools/trust_domain.xml.template
+++ b/guest-tools/trust_domain.xml.template
@@ -8,7 +8,7 @@
   <vcpu placement="static">16</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
-    <loader>/usr/share/qemu/OVMF.fd</loader>
+    <loader type='rom' readonly='yes'>/usr/share/qemu/OVMF.fd</loader>
     <boot dev='hd'/>
   </os>
   <features>


### PR DESCRIPTION
until now, libvirt generates apparmor permission
for the OVMF file to "rk" whatever is the value of the readonly flag.

on recent libvirt version 10.0, there is a fix
https://github.com/libvirt/libvirt/commit/c019350a76d79405dd3e22d3023b71384f2924f2 that generates the apparmor permission "rwk" if the flag readonly is set to no (or not set - no is the default value).

however, libvirt has an enforcement on the OVMF.fd file that denies the "w" permission. our qemu process
will failed because of this.

this patch will set the readonly explicitly to yes so that only the permissions "rk" are generated and will pass apparmor control