### PR TITLE
Update the README for create-td-image.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,18 @@ This can be performed on any Ubuntu 22.04 or newer system - an Intel TDX-specifi
 
 ### 5.1 Create a New TD Image
 
-A TD image can be generated with the following commands.
-The resulting image will be based on an Ubuntu 24.04 cloud image ([`ubuntu-24.04-server-cloudimg-amd64.img`](https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img)), the default root password is `123456`, and other default settings are used.
-Please note the most important options described after the commands and have a look at the `create-td-image.sh` script for more available options.
+A TD image can be generated with the following commands:
 
 ```bash
 cd tdx/guest-tools/image/
 sudo ./create-td-image.sh -v 24.04
 ```
+
+For now passing only `-v 24.04` is supported but other OS versions will be supported in the future.
+
+The resulting image will be based on an Ubuntu 24.04 cloud image ([`ubuntu-24.04-server-cloudimg-amd64.img`](https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img)),
+the default root password is `123456`, and other default settings are used.
+Please note the most important options described after the commands and have a look at the `create-td-image.sh` script for more available options.
 
 Important options for TD image creation:
 * If you're behind a proxy, use `sudo -E` to preserve user environment.

--- a/README.md
+++ b/README.md
@@ -147,13 +147,6 @@ Please note the most important options described after the commands and have a l
 
 Important options for TD image creation:
 * If you're behind a proxy, use `sudo -E` to preserve user environment.
-* To adjust the base image, set the following two environment variables before running the script:
-
-    ```bash
-    export OFFICIAL_UBUNTU_IMAGE="https://cloud-images.ubuntu.com/noble/current/"
-    export CLOUD_IMG="noble-server-cloudimg-amd64.img"
-    ```
-
 * The used kernel type (`generic` or `intel`) will be reflected in the name of the resulting image so it is easy to distinguish.
 
 ### 5.2 Convert a Regular VM Image into a TD Image

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Please note the most important options described after the commands and have a l
 
 ```bash
 cd tdx/guest-tools/image/
-sudo ./create-td-image.sh
+sudo ./create-td-image.sh -v 24.04
 ```
 
 Important options for TD image creation:

--- a/guest-tools/image/create-td-image.sh
+++ b/guest-tools/image/create-td-image.sh
@@ -37,8 +37,6 @@
 # User can tune the current script by providing arguments to the script
 # or setting following environment variables:
 
-# CLOUD_IMG: the ubuntu image name
-# OFFICIAL_UBUNTU_IMAGE: the url where we can download the CLOUD_IMAGE file
 # UBUNTU_VERSION: the ubuntu version (24.04, 24.10, ...)
 # GUEST_USER: the username in the image
 # GUEST_PASSWORD: the user password in the image
@@ -124,7 +122,7 @@ process_args() {
     fi
 
     # generate variables
-    CLOUD_IMG=${CLOUD_IMG:-"ubuntu-${UBUNTU_VERSION}-server-cloudimg-amd64.img"}
+    CLOUD_IMG="ubuntu-${UBUNTU_VERSION}-server-cloudimg-amd64.img"
     CLOUD_IMG_PATH=$(realpath "${SCRIPT_DIR}/${CLOUD_IMG}")
     if [[ "${TDX_SETUP_INTEL_KERNEL}" == "1" ]]; then
 	GUEST_IMG_PATH=$(realpath "tdx-guest-ubuntu-${UBUNTU_VERSION}-intel.qcow2")
@@ -147,7 +145,7 @@ download_image() {
         rm ${SCRIPT_DIR}/"SHA256SUMS"
     fi
 
-    OFFICIAL_UBUNTU_IMAGE=${OFFICIAL_UBUNTU_IMAGE:-"https://cloud-images.ubuntu.com/releases/${UBUNTU_VERSION}/release/"}
+    OFFICIAL_UBUNTU_IMAGE="https://cloud-images.ubuntu.com/releases/${UBUNTU_VERSION}/release/"
     wget "${OFFICIAL_UBUNTU_IMAGE}/SHA256SUMS" -O ${SCRIPT_DIR}/"SHA256SUMS"
 
     while :; do


### PR DESCRIPTION
From now on, create-td-image.sh will need a ubuntu release as input,
At the moment, 24.04 is the only acceptable value but soon 24.10 will be added with the release for 24.10

Fixes #285 