### PR TITLE
enable normal user for libvirt in setup script

### DIFF
--- a/setup-tdx-common
+++ b/setup-tdx-common
@@ -98,3 +98,27 @@ grub_set_kernel() {
     fi
     grub_switch_kernel "${KERNEL_RELEASE}"
 }
+
+# Enable non-root user to run TDs
+# Try to detect the normal user when the script is run with sudo
+# If the script is run as root, just skip this step
+#
+# This script modifies the configuration file /etc/libvirt/qemu.conf:
+# user = <user>
+# group = <group>
+# dynamic_ownership = 0
+enable_normal_user_libvirt() {
+    if [[ -z "${SUDO_USER}" ]]; then
+       return
+    fi
+    LIBVIRT_USER=${SUDO_USER}
+    LIBVIRT_GROUP=$(id -g ${SUDO_USER})
+
+    echo "Enable non-root user ${LIBVIRT_USER} to run TDs"
+    sed -E -i "s/\#user[ ]*=[ ]*\".+\"/user = \"${LIBVIRT_USER}\"/g" /etc/libvirt/qemu.conf
+    sed -E -i "s/\#group[ ]*=[ ]*\".+\"/group = \"${LIBVIRT_GROUP}\"/g" /etc/libvirt/qemu.conf
+    sed -E -i "s/\#dynamic_ownership[ ]*=[ ]*.+/dynamic_ownership = 0/g" /etc/libvirt/qemu.conf
+
+    # restart libvirtd
+    systemctl restart libvirtd || true
+}

--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -129,6 +129,9 @@ else
   echo "Skip installing attestation components..."
 fi
 
+# configure non-root user for libvirt
+enable_normal_user_libvirt
+
 echo "========================================================================"
 echo "The host OS setup has been done successfully. Now, please enable Intel TDX in the BIOS."
 echo "========================================================================"


### PR DESCRIPTION
enable by default non root user for libvirt
since everytime, I run into permissions issue and realized I missed this step in the README to enable non-root user
It is a waste of time and this commit tries to automate this for the users