### PR TITLE
tests : skip attestation tests if platform is not registered

### DIFF
--- a/attestation/check-registration.sh
+++ b/attestation/check-registration.sh
@@ -47,7 +47,7 @@ then
     then
         check_mpa_status
     else
-        echo "mpa_manage is available, assuming platform not registered."
+        echo "mpa_manage is not available, assuming platform not registered."
     fi
 fi
 

--- a/attestation/check-registration.sh
+++ b/attestation/check-registration.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This file is part of Canonical's TDX repository which includes tools
+# to setup and configure a confidential computing environment
+# based on Intel TDX technology.
+# See the LICENSE file in the repository for the license text.
+
+# Copyright 2024 Canonical Ltd.
+# SPDX-License-Identifier: GPL-3.0-only
+
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3,
+# as published by the Free Software Foundation.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranties
+# of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+# check platform registration
+
+set -e
+
+REGISTRATION_SUCCESS=1
+
+check_mpa_status() {
+    # Run command: mpa_manage -get_last_registration_error_code
+    # If the platform has been registered successfully, the command will output:
+    # Last reported registration error code: 0
+    if mpa_manage -get_last_registration_error_code | grep "error code: 0" 2>&1 > /dev/null
+    then
+	REGISTRATION_SUCCESS=0
+    fi
+}
+
+# check if MPA is used for platform registration
+if systemctl is-enabled mpa_registration_tool.service  2>&1 > /dev/null
+then
+    if command -v mpa_manage 2>&1 > /dev/null
+    then
+	check_mpa_status
+    fi
+fi
+
+exit $REGISTRATION_SUCCESS

--- a/attestation/check-registration.sh
+++ b/attestation/check-registration.sh
@@ -33,7 +33,10 @@ check_mpa_status() {
     # Last reported registration error code: 0
     if mpa_manage -get_last_registration_error_code | grep "error code: 0" 2>&1 > /dev/null
     then
-	REGISTRATION_SUCCESS=0
+        REGISTRATION_SUCCESS=0
+        echo "mpa_manage: registration status OK."
+    else
+        echo "mpa_manage: registration status NOK: platform not registered"
     fi
 }
 
@@ -42,7 +45,9 @@ if systemctl is-enabled mpa_registration_tool.service  2>&1 > /dev/null
 then
     if command -v mpa_manage 2>&1 > /dev/null
     then
-	check_mpa_status
+        check_mpa_status
+    else
+        echo "mpa_manage is available, assuming platform not registered."
     fi
 fi
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    quote_generation: marks quote generation tests (deselect with '-m "not quote_generation"')

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -1,8 +1,28 @@
 import os
 import pytest
+import subprocess
 
 import Qemu
 import util
+
+script_path=os.path.dirname(os.path.realpath(__file__))
+
+# Is platform registered for quote generation
+def is_platform_registered():
+    try:
+        subprocess.check_call([f'{script_path}/../../attestation/check-registration.sh'])
+    except:
+        return 0
+    return 1
+
+def pytest_runtest_setup(item):
+    """
+    Test setup function
+    """
+    # skip the test if needed
+    for mark in item.iter_markers(name='quote_generation'):
+        if not is_platform_registered():
+            pytest.skip('Platform not registered, skip quote generation test')
 
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests(tmpdir):

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -12,8 +12,8 @@ def is_platform_registered():
     try:
         subprocess.check_call([f'{script_path}/../../attestation/check-registration.sh'])
     except:
-        return 0
-    return 1
+        return False
+    return True
 
 def pytest_runtest_setup(item):
     """

--- a/tests/tests/test_guest_ita.py
+++ b/tests/tests/test_guest_ita.py
@@ -19,12 +19,14 @@ import os
 import time
 import json
 import subprocess
+import pytest
 
 import Qemu
 import util
 
 ubuntu_codename = None
 
+@pytest.mark.quote_generation
 def test_guest_measurement_trust_authority_success():
     """
     Trust Authority CLI quote generation success
@@ -33,6 +35,7 @@ def test_guest_measurement_trust_authority_success():
     quote_str = run_trust_authority()
     check_ita_output(quote_str, for_success = True)
 
+@pytest.mark.quote_generation
 def test_guest_measurement_trust_authority_failure():
     """
     Trust Authority CLI quote generation failure

--- a/tests/tests/test_guest_tdxattest.py
+++ b/tests/tests/test_guest_tdxattest.py
@@ -17,6 +17,7 @@
 
 import random
 import string
+import pytest
 
 import Qemu
 
@@ -28,6 +29,7 @@ import Qemu
 # - configfs tsm : the application use configsf tsm to ask the guest kernel
 #                  to contact the QGSD service for the quote generation
 
+@pytest.mark.quote_generation
 def test_guest_tdxattest_tsm():
     """
     TDX attest library
@@ -47,6 +49,7 @@ def test_guest_tdxattest_tsm():
 
         assert 'Successfully get the TD Quote' in stdout.read().decode()
 
+@pytest.mark.quote_generation
 def test_guest_tdxattest_tsm_failure():
     """
     TDX attest library
@@ -62,6 +65,7 @@ def test_guest_tdxattest_tsm_failure():
         ret, stdout, stderr = ssh.exec_command('/usr/share/doc/libtdx-attest-dev/examples/test_tdx_attest')
         assert (ret != 0) and ('Failed to get the quote' in stderr.read().decode())
 
+@pytest.mark.quote_generation
 def test_guest_tdxattest_vsock():
     """
     TDX attest library
@@ -80,6 +84,7 @@ def test_guest_tdxattest_vsock():
 
         assert 'Successfully get the TD Quote' in stdout.read().decode()
 
+@pytest.mark.quote_generation
 def test_guest_tdxattest_vsock_wrong_qgs_addr(qm):
     """
     Success even when QGS address is not properly configured
@@ -103,6 +108,7 @@ def test_guest_tdxattest_vsock_wrong_qgs_addr(qm):
 
     assert 'Successfully get the TD Quote' in stdout.read().decode()
 
+@pytest.mark.quote_generation
 def test_guest_tdxattest_vsock_failure():
     """
     TDX attest library
@@ -118,6 +124,7 @@ def test_guest_tdxattest_vsock_failure():
         ret, stdout, stderr = ssh.exec_command('/usr/share/doc/libtdx-attest-dev/examples/test_tdx_attest')
         assert (ret != 0) and ('Failed to get the quote' in stderr.read().decode())
 
+@pytest.mark.quote_generation
 def test_guest_tdxattest_failure():
     """
     TDX attest library
@@ -134,6 +141,7 @@ def test_guest_tdxattest_failure():
 
         assert (ret != 0) and ('Failed to get the quote' in stderr.read().decode())
 
+@pytest.mark.quote_generation
 def test_guest_tdxattest_failure_1(qm):
     """
     Failure when vsock disabled and QGS addr is not properly configured

--- a/tests/tests/test_stress_quote.py
+++ b/tests/tests/test_stress_quote.py
@@ -15,8 +15,11 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import pytest
+
 import Qemu
 
+@pytest.mark.quote_generation
 def test_stress_tdxattest_tsm():
     """
     Stress test on quote generation


### PR DESCRIPTION
when the tests run on platform that is not registered to the intel trust service, quote cannot be generated. in that case, the tests must be skipped.

this commit add a script `check-registration.sh` that allows to detect if the platform has been properly registered, if not, all the tests marked as quote_generation will be skipped