### PR TITLE
create-td-image : on 24.04, the script fails if passt is installed

### DIFF
--- a/guest-tools/image/create-td-image.sh
+++ b/guest-tools/image/create-td-image.sh
@@ -87,7 +87,9 @@ check_tool() {
 # for both 24.04 and 24.10
 workaround_passt() {
     if command -v passt 2>&1 > /dev/null ; then
-       apt autoremove passt -y
+       echo "You have the package passt installed, this will prevent"
+       echo "  the script to work properly. This package has to be removed:"
+       apt autoremove passt
     fi
 }
 

--- a/guest-tools/image/create-td-image.sh
+++ b/guest-tools/image/create-td-image.sh
@@ -82,10 +82,10 @@ check_tool() {
 # On Ubuntu noble 24.04
 # if passt is install and virt-customize runs as root, virt-customize
 # will fail, this is a work-around for this issue
+# Furthermore, we see some instability to reach ubuntu archive when
+# passt is used on 24.10, so for now, we decide to remove it
+# for both 24.04 and 24.10
 workaround_passt() {
-    if [[ "$(lsb_release -rs)" != "24.04" ]]; then
-	return
-    fi
     if command -v passt 2>&1 > /dev/null ; then
        apt autoremove passt -y
     fi


### PR DESCRIPTION
Fixes #303 