### PR TITLE
tdtest : fix passing arguments to pytest

### DIFF
--- a/tests/tdtest
+++ b/tests/tdtest
@@ -77,4 +77,4 @@ export TDXTEST_GUEST_IMG
 
 echo "Run tests with TD image: ${TDXTEST_GUEST_IMG}"
 echo "  pytest args: ${pytest_args}"
-tox -- --ignore=lib/ "${pytest_args}"
+tox -- --ignore=lib/ ${pytest_args}


### PR DESCRIPTION
Fixes #321 