### PR TITLE
Make grub-install to not alter the EFI boot order

### DIFF
--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -60,7 +60,10 @@ grub_cmdline_kvm() {
   if ! grep -q -E "GRUB_CMDLINE_LINUX.*=.*\".*kvm_intel.tdx( )*=1.*\"" /etc/default/grub; then
     sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 kvm_intel.tdx=1\"/g" /etc/default/grub
     update-grub
-    grub-install
+    # --no-nvram : to prevent grub-install from update the EFI boot order
+    # we would like to keep the current boot order in place in case the machine
+    # is being managed by MAAS that expects the device to PXE boot
+    grub-install --no-nvram
   fi
 }
 
@@ -75,7 +78,10 @@ grub_cmdline_nohibernate() {
   if ! grep -q -E "GRUB_CMDLINE_LINUX.*=.*\".*nohibernate.*\"" /etc/default/grub; then
     sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 nohibernate\"/g" /etc/default/grub
     update-grub
-    grub-install
+    # --no-nvram : to prevent grub-install from update the EFI boot order
+    # we would like to keep the current boot order in place in case the machine
+    # is being managed by MAAS that expects the device to PXE boot
+    grub-install --no-nvram
   fi
 }
 

--- a/tests/tests/boot/test_boot_basic.py
+++ b/tests/tests/boot/test_boot_basic.py
@@ -47,7 +47,7 @@ def test_guest_early_printk(qm):
     add_earlyprintk_cmd = r'''
       sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 earlyprintk=ttyS0,115200\"/g" /etc/default/grub
       update-grub
-      grub-install
+      grub-install --no-nvram
     '''
     m.check_exec(add_earlyprintk_cmd)
 


### PR DESCRIPTION
Right now, when we run the TDX setup, we call grub-install to finalize some kernel boot parameters additions, grub-install modifies the EFI boot order (by modifying the NVRAM). This boot order change will place Ubuntu as the first boot entry and breaks by the way MAAS that expects the machine to PXE boot in the first place.

We use `--no-nvram` argument to tell grub-install to not change the boot order