### PR TITLE
tests : add check on the max nb of TDs that can be run in parralel

### DIFF
--- a/tests/lib/util.py
+++ b/tests/lib/util.py
@@ -51,7 +51,7 @@ def get_max_td_vms():
      - first key
      - shared keys
      - TDX keys
-    So if we have 128 keys and we decide to split this rango into 2 equal sets (in BIOS)
+    So if we have 128 keys and we decide to split this range into 2 equal sets (in BIOS)
     TDX key space will only have 63 keys instead of 64.
     The nb of TDX key space can be read from the IA32_MKTME_KEYID_PARTITIONING MSR (0x87)
     """

--- a/tests/lib/util.py
+++ b/tests/lib/util.py
@@ -45,6 +45,16 @@ def tcp_port_available():
     return port
 
 def get_max_td_vms():
+    """
+    MKTME encryption engine is used both for legacy MKTME operation and TDX operation
+    The key space is partitionned in 3 ranges:
+     - first key
+     - shared keys
+     - TDX keys
+    So if we have 128 keys and we decide to split this rango into 2 equal sets (in BIOS)
+    TDX key space will only have 63 keys instead of 64.
+    The nb of TDX key space can be read from the IA32_MKTME_KEYID_PARTITIONING MSR (0x87)
+    """
     cmd = ['rdmsr', '0x87']
     rc = subprocess.run(cmd, capture_output=True)
     assert rc.returncode == 0, "Failed getting max td vms"


### PR DESCRIPTION
    There is a limit on the number of TDs that can be run in parralel.                         
    This limit can be due to several factors, but the most prevalent factor                    
    is the number of keys the CPU can allocate to TDs.                                         
    In fact, TDX takes advantage of an existing CPU feature called MK-TME                      
    (Multi-key Total Memory Encryption) to encrypt the VM memory. It enables                   
    the CPU to encrypt each TD’s memory with a unique Advanced Encryption Standard (AES) key.  
    MK-TME offers a number of keys and this key space is partionned into 2 sets:               
    Shared (VMM) and Private (TDX). The number of key in the Private space defines the         
    maximum number of TDs we can run in parralel.                                              
                                                                                               
    This test verifies that we can run TDs up to this limit and any new TD creation            
    is refused by qemu in a nice way.

You can run this test with:
```
$ cd tests
$ sudo ./tdtest -k 'test_stress_max_guests'
```