### PR TITLE
Add kobuk prefix to apt configuration files

### DIFF
--- a/setup-tdx-common
+++ b/setup-tdx-common
@@ -44,7 +44,7 @@ add_kobuk_ppa() {
 
   add-apt-repository -y ppa:${team}/${ppa_id}
 
-  cat <<EOF | tee /etc/apt/preferences.d/tdx-${team}-${ppa_id}-pin-4000
+  cat <<EOF | tee /etc/apt/preferences.d/kobuk-tdx-${team}-${ppa_id}-pin-4000
 Package: *
 Pin: release o=${distro_id}
 Pin-Priority: 4000

--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -56,7 +56,10 @@ apt update
 apt install --yes software-properties-common gawk &> /dev/null
 
 # cleanup
-rm -f /etc/apt/preferences.d/*tdx-*
+# NB: '*' before kobuk to keep backward compatiblity to make sure
+# we clean up all conf files that have been deployed in the
+# previous releases
+rm -f /etc/apt/preferences.d/*kobuk*tdx-*
 rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 
 # We want wordsplitting if there is multiple entries

--- a/setup-tdx-host.sh
+++ b/setup-tdx-host.sh
@@ -95,7 +95,10 @@ apt update
 apt install --yes software-properties-common gawk &> /dev/null
 
 # cleanup
-rm -f /etc/apt/preferences.d/*tdx-*
+# NB: '*' before kobuk to keep backward compatiblity to make sure
+# we clean up all conf files that have been deployed in the
+# previous releases
+rm -f /etc/apt/preferences.d/*kobuk*tdx-*
 rm -f /etc/apt/apt.conf.d/99unattended-upgrades-kobuk
 
 # stop at error


### PR DESCRIPTION
To pin TDX packages, we add apt configuration files for all the PPAs we use to pull in the packages to the OS. Add the prefix kobuk to these configuration file names to avoid any potential conflict with other TDX setup from Intel or other users.