### PR TITLE
setup-tdx-guest : fix nvidia drivers install

### DIFF
--- a/setup-tdx-guest.sh
+++ b/setup-tdx-guest.sh
@@ -147,14 +147,7 @@ EOF
     dpkg -i cuda-keyring_1.1-1_all.deb
     apt update
     apt install --yes cuda-toolkit-12-8
-    wget https://us.download.nvidia.com/tesla/570.86.15/nvidia-driver-local-repo-ubuntu2404-570.86.15_1.0-1_amd64.deb
-    dpkg -i ./nvidia-driver-local-repo-ubuntu2404-570.86.15_1.0-1_amd64.deb
-    cp /var/nvidia-driver-local-repo-ubuntu2404-570.86.15/nvidia-driver-local-41F54E74-keyring.gpg /usr/share/keyrings/
-    # with the release of nvidia drivers v575, the installation of nvidia-driver-570-open fails
-    # both packages libnvidia-cfg1-570 and libnvidia-cfg1-575 are asked to be installed
-    # work-around : force nvidia-persistenced to stay on version 570 so that it does not ask for libnvidia-cfg1-575
-    apt install --yes nvidia-persistenced=570.148.08-1ubuntu1
-    apt install --yes nvidia-driver-570-open=570.148.08-1ubuntu1
+    apt install --yes nvidia-driver-570-open
 
     # install nvtop
     echo "Setup components for NVIDIA H100... Install utilities"


### PR DESCRIPTION
Since Nvidia fixed the issue for installing the version 750,
We can now remove the work-around

Fixes #386 