### PR TITLE
run_td: Add arguments to set vcpus and memory

### DIFF
--- a/guest-tools/run_td
+++ b/guest-tools/run_td
@@ -81,8 +81,8 @@ def add_gpus(cmd, gpus):
         cmd.extend(gpu_cmd)
         index = index + 1
 
-def do_run(img_path, gpus):
-    print('Run VM')
+def do_run(img_path, vcpus, mem, gpus):
+    print(f'Run VM {vcpus} vcpus {mem} RAM')
     print(f'  Image: {img_path}')
     if len(gpus):
         print(f'  Passthrough GPUs: {gpus}')
@@ -95,11 +95,11 @@ def do_run(img_path, gpus):
 
     qemu_cmds = ['qemu-system-x86_64',
 		 '-accel', 'kvm',
-		 '-m', '100G', '-smp', '32',
+		 '-m', f'{mem}', '-smp', f'{vcpus}',
 		 '-name', f'{process_name},process={process_name},debug-threads=on',
 		 '-cpu', f'{cpu_args}',
 		 '-object', '{"qom-type":"tdx-guest","id":"tdx","quote-generation-socket":{"type": "vsock", "cid":"2","port":"4050"}}',
-		 '-object', 'memory-backend-ram,id=mem0,size=100G',
+		 '-object', f'memory-backend-ram,id=mem0,size={mem}',
 		 '-machine', 'q35,kernel_irqchip=split,confidential-guest-support=tdx,memory-backend=mem0',
 		 '-bios', tdvf_params,
 		 '-nographic', '-daemonize',
@@ -127,11 +127,18 @@ def run_td(args):
        return
     if args.image:
         td_img=args.image
-    do_run(td_img, args.gpus.split(',') if args.gpus else [])
+    if args.mem:
+        td_mem=args.mem
+    if args.vcpus:
+        td_vcpus=args.vcpus
+
+    do_run(td_img, td_vcpus, td_mem, args.gpus.split(',') if args.gpus else [])
 
 if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument("--image", type=str, help="Guest image")
+   parser.add_argument("--vcpus", type=str, help="Number of VCPUs. 32 by default.", default='32')
+   parser.add_argument("--mem", type=str, help="Memory. 100G by default", default='100G')
    parser.add_argument("--gpus", type=str, help="GPUs to pass-through")
    parser.add_argument("--clean", action='store_true', help="Clean the current VM")
    args = parser.parse_args()


### PR DESCRIPTION
Add the optional --vcpus and --mem arguments to allow launching TDs with custom configuration.

The default values remain the same, 32 vcpus and 100G of memory.