### PR TITLE
tdtest : fix the argument passing to pytest

### DIFF
--- a/tests/tdtest
+++ b/tests/tdtest
@@ -48,6 +48,7 @@ parse_params() {
             ;;
         *)
             # other arguments will be passed to pytest
+            pytest_args="$@"
             break
             ;;
         esac
@@ -76,4 +77,4 @@ export TDXTEST_GUEST_IMG
 
 echo "Run tests with TD image: ${TDXTEST_GUEST_IMG}"
 echo "  pytest args: ${pytest_args}"
-tox -- --ignore=lib/ "$@"
+tox -- --ignore=lib/ "$pytest_args"


### PR DESCRIPTION
ignore tdtest specific arguments that should not be passed to pytest