### PR TITLE
Fix the 8 gpu PPCIE mode detection logic

### DIFF
--- a/guest-tools/run_td
+++ b/guest-tools/run_td
@@ -187,7 +187,7 @@ def do_run(img_path, gpus):
 
     add_vsock(qemu_cmds)
 
-    if args.gpus and len(args.gpus) == 8:
+    if gpus and len(gpus) == 8:
         setup_ppcie(qemu_cmds)
     else:
         add_gpus(qemu_cmds, gpus)


### PR DESCRIPTION
The code to automatically set PPCIE mode used the original string instead of the parsed and split gpu list, which results in the code never actually running when it's supposed to.